### PR TITLE
add exit for every question interupted in the cli

### DIFF
--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -3,6 +3,7 @@ package cmdAccount
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/logrusorgru/aurora"
@@ -27,8 +28,12 @@ func createHandler(cmd *cobra.Command, args []string) {
 	password := cmd.Flag("password").Value.String()
 	if password == "" {
 		var passwordConfirmation string
-		survey.AskOne(&survey.Password{Message: "Please set a password ?"}, &password, nil)
-		survey.AskOne(&survey.Password{Message: "Repeat your password ?"}, &passwordConfirmation, nil)
+		if survey.AskOne(&survey.Password{Message: "Please set a password ?"}, &password, nil) != nil {
+			os.Exit(0)
+		}
+		if survey.AskOne(&survey.Password{Message: "Repeat your password ?"}, &passwordConfirmation, nil) != nil {
+			os.Exit(0)
+		}
 		if password != passwordConfirmation {
 			panic(errors.New("Password confirmation invalid"))
 		}

--- a/cmd/account/export.go
+++ b/cmd/account/export.go
@@ -2,6 +2,7 @@ package cmdAccount
 
 import (
 	"errors"
+	"os"
 
 	"github.com/mesg-foundation/application/account"
 
@@ -24,14 +25,18 @@ func exportHandler(cmd *cobra.Command, args []string) {
 	path := cmd.Flag("path").Value.String()
 	acc := cmdUtils.AccountFromFlagOrAsk(cmd, "Choose the account you want to export")
 	password := cmd.Flag("password").Value.String()
-	if password == "" {
-		survey.AskOne(&survey.Password{Message: "Type the current password ?"}, &password, nil)
+	if password == "" && survey.AskOne(&survey.Password{Message: "Type the current password ?"}, &password, nil) != nil {
+		os.Exit(0)
 	}
 	newPassword := cmd.Flag("new-password").Value.String()
 	if newPassword == "" {
 		var passwordConfirmation string
-		survey.AskOne(&survey.Password{Message: "Type the new password for your account ?"}, &newPassword, nil)
-		survey.AskOne(&survey.Password{Message: "Repeat your password ?"}, &passwordConfirmation, nil)
+		if survey.AskOne(&survey.Password{Message: "Type the new password for your account ?"}, &newPassword, nil) != nil {
+			os.Exit(0)
+		}
+		if survey.AskOne(&survey.Password{Message: "Repeat your password ?"}, &passwordConfirmation, nil) != nil {
+			os.Exit(0)
+		}
 		if newPassword != passwordConfirmation {
 			panic(errors.New("Password confirmation invalid"))
 		}

--- a/cmd/account/import.go
+++ b/cmd/account/import.go
@@ -3,6 +3,7 @@ package cmdAccount
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/mesg-foundation/application/account"
@@ -23,14 +24,18 @@ var Import = &cobra.Command{
 
 func importHandler(cmd *cobra.Command, args []string) {
 	password := cmd.Flag("password").Value.String()
-	if password == "" {
-		survey.AskOne(&survey.Password{Message: "Type the current password ?"}, &password, nil)
+	if password == "" && survey.AskOne(&survey.Password{Message: "Type the current password ?"}, &password, nil) != nil {
+		os.Exit(0)
 	}
 	newPassword := cmd.Flag("new-password").Value.String()
 	if newPassword == "" {
 		var passwordConfirmation string
-		survey.AskOne(&survey.Password{Message: "Type the new password for your account ?"}, &newPassword, nil)
-		survey.AskOne(&survey.Password{Message: "Repeat your password ?"}, &passwordConfirmation, nil)
+		if survey.AskOne(&survey.Password{Message: "Type the new password for your account ?"}, &newPassword, nil) != nil {
+			os.Exit(0)
+		}
+		if survey.AskOne(&survey.Password{Message: "Repeat your password ?"}, &passwordConfirmation, nil) != nil {
+			os.Exit(0)
+		}
 		if newPassword != passwordConfirmation {
 			panic(errors.New("Password confirmation invalid"))
 		}

--- a/cmd/service/start.go
+++ b/cmd/service/start.go
@@ -2,6 +2,7 @@ package cmdService
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/mesg-foundation/application/cmd/utils"
 
@@ -25,19 +26,19 @@ var Start = &cobra.Command{
 
 func startHandler(cmd *cobra.Command, args []string) {
 	account := cmdUtils.AccountFromFlagOrAsk(cmd, "Select an account")
-	if stake == 0 {
-		survey.AskOne(&survey.Input{
-			Message: "How much do you want to stake (MESG) ?",
-			Help:    "More details on the stake here",
-			Default: "0",
-		}, &stake, nil)
+	if stake == 0 && survey.AskOne(&survey.Input{
+		Message: "How much do you want to stake (MESG) ?",
+		Help:    "More details on the stake here",
+		Default: "0",
+	}, &stake, nil) != nil {
+		os.Exit(0)
 	}
-	if duration == 0 {
-		survey.AskOne(&survey.Input{
-			Message: "How long will you run this service (hours) ?",
-			Help:    "More details on the duration here",
-			Default: "0",
-		}, &duration, nil)
+	if duration == 0 && survey.AskOne(&survey.Input{
+		Message: "How long will you run this service (hours) ?",
+		Help:    "More details on the duration here",
+		Default: "0",
+	}, &duration, nil) != nil {
+		os.Exit(0)
 	}
 	if !cmdUtils.Confirm(cmd, "Are you sure to run this service and stake your tokens ?") {
 		return

--- a/cmd/utils/accountable.go
+++ b/cmd/utils/accountable.go
@@ -1,6 +1,8 @@
 package cmdUtils
 
 import (
+	"os"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/mesg-foundation/application/account"
 	"github.com/spf13/cobra"
@@ -23,10 +25,12 @@ func FindAccount(accountValue string) (acc accounts.Account) {
 func AskAccount(message string) (acc accounts.Account) {
 	accounts := account.List()
 	var selectedAccount string
-	survey.AskOne(&survey.Select{
+	if survey.AskOne(&survey.Select{
 		Message: message,
 		Options: accountOptions(accounts),
-	}, &selectedAccount, nil)
+	}, &selectedAccount, nil) != nil {
+		os.Exit(0)
+	}
 	acc = FindAccount(selectedAccount)
 	return
 }

--- a/cmd/utils/confirmable.go
+++ b/cmd/utils/confirmable.go
@@ -1,6 +1,8 @@
 package cmdUtils
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 )
@@ -8,8 +10,8 @@ import (
 // Confirm checks that the flag "confirm" is set and otherwise ask a confirmation in the command line
 func Confirm(cmd *cobra.Command, message string) (confirmed bool) {
 	confirmed = cmd.Flag("confirm").Value.String() == "true"
-	if !confirmed {
-		survey.AskOne(&survey.Confirm{Message: message}, &confirmed, nil)
+	if !confirmed && survey.AskOne(&survey.Confirm{Message: message}, &confirmed, nil) != nil {
+		os.Exit(0)
 	}
 	return
 }

--- a/cmd/utils/payable.go
+++ b/cmd/utils/payable.go
@@ -1,6 +1,8 @@
 package cmdUtils
 
 import (
+	"os"
+
 	"github.com/mesg-foundation/application/conversion"
 	"github.com/spf13/cobra"
 	survey "gopkg.in/AlecAivazis/survey.v1"
@@ -9,8 +11,8 @@ import (
 // GetOrAskAmount return the amount in MESG based on the flag or the user input
 func GetOrAskAmount(cmd *cobra.Command, message string) (amount *conversion.Amount, err error) {
 	value := cmd.Flag("amount").Value.String()
-	if value == "" {
-		survey.AskOne(&survey.Input{Message: message}, &value, nil)
+	if value == "" && survey.AskOne(&survey.Input{Message: message}, &value, nil) != nil {
+		os.Exit(0)
 	}
 	amount = &conversion.Amount{}
 	err = amount.FromString(value)

--- a/cmd/workflow/pause.go
+++ b/cmd/workflow/pause.go
@@ -2,6 +2,7 @@ package cmdWorkflow
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/mesg-foundation/application/cmd/utils"
 	survey "gopkg.in/AlecAivazis/survey.v1"
@@ -27,11 +28,13 @@ func pauseHandler(cmd *cobra.Command, args []string) {
 	if workflow == "" {
 		// TODO add real list
 		workflows := []string{"Workflow #1", "Workflow #2"}
-		survey.AskOne(&survey.Select{
+		if survey.AskOne(&survey.Select{
 			Message: "Choose the workflow you want to pause",
 			Default: workflows[0],
 			Options: workflows,
-		}, &workflow, nil)
+		}, &workflow, nil) != nil {
+			os.Exit(0)
+		}
 	}
 	if !cmdUtils.Confirm(cmd, "Are you sure ?") {
 		return

--- a/cmd/workflow/resume.go
+++ b/cmd/workflow/resume.go
@@ -2,6 +2,7 @@ package cmdWorkflow
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/mesg-foundation/application/cmd/utils"
 	survey "gopkg.in/AlecAivazis/survey.v1"
@@ -27,11 +28,13 @@ func resumeHandler(cmd *cobra.Command, args []string) {
 	if workflow == "" {
 		// TODO add real list
 		workflows := []string{"Workflow #1", "Workflow #2"}
-		survey.AskOne(&survey.Select{
+		if survey.AskOne(&survey.Select{
 			Message: "Choose the workflow you want to resume",
 			Default: workflows[0],
 			Options: workflows,
-		}, &workflow, nil)
+		}, &workflow, nil) != nil {
+			os.Exit(0)
+		}
 	}
 	if !cmdUtils.Confirm(cmd, "Are you sure ?") {
 		return

--- a/cmd/workflow/topup.go
+++ b/cmd/workflow/topup.go
@@ -2,6 +2,7 @@ package cmdWorkflow
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/mesg-foundation/application/cmd/utils"
 	survey "gopkg.in/AlecAivazis/survey.v1"
@@ -31,11 +32,13 @@ func topupHandler(cmd *cobra.Command, args []string) {
 	if workflow == "" {
 		// TODO add real list
 		workflows := []string{"Workflow #1", "Workflow #2"}
-		survey.AskOne(&survey.Select{
+		if survey.AskOne(&survey.Select{
 			Message: "Choose the workflow you want to pause",
 			Default: workflows[0],
 			Options: workflows,
-		}, &workflow, nil)
+		}, &workflow, nil) != nil {
+			os.Exit(0)
+		}
 	}
 	if !cmdUtils.Confirm(cmd, "Are you sure ?") {
 		return


### PR DESCRIPTION
every time we use `survey.AskOne` to ask a question to the user in the cli, it returns an error if it's interrupted or if the result of the user is invalid. In the case of this error not nil I just do a `os.Exit(0)` to exit the process immediately 

fix #66