### PR TITLE
Output simplification for system services

### DIFF
--- a/systemservices/ethwallet/mesg.yml
+++ b/systemservices/ethwallet/mesg.yml
@@ -11,23 +11,11 @@ tasks:
     name: "List accounts"
     description: "Return the addresses of existing account."
     outputs:
-      success:
-        name: "Success"
-        description: "Output when the task executes successfully."
-        data:
-          addresses:
-            name: "Addresses"
-            description: "List of addresses."
-            type: String
-            repeated: true
-      error: &outputError
-        name: "Error"
-        description: "Output when an error occurs."
-        data:
-          message:
-            name: "Message"
-            description: "The error message."
-            type: String
+      addresses:
+        name: "Addresses"
+        description: "List of addresses."
+        type: String
+        repeated: true
   create:
     name: "Create a new account"
     description: "Create a new account with a passphrase. Make sure to backup the passphrase."
@@ -37,15 +25,10 @@ tasks:
         description: "Passphrase to use with the account."
         type: String
     outputs:
-      success:
-        name: "Success"
-        description: "Output when the task executes successfully."
-        data:
-          address: &address
-            name: "Address"
-            description: "The public address of the account."
-            type: String
-      error: *outputError
+      address: &address
+        name: "Address"
+        description: "The public address of the account."
+        type: String
   delete:
     name: "Delete an account"
     description: "Delete an account from the wallet. Need the address and its associated passphrase."
@@ -53,37 +36,27 @@ tasks:
       address: *address
       passphrase: *passphrase
     outputs:
-      success:
-        name: "Success"
-        description: "Output when the task executes successfully."
-        data:
-          address: *address
-      error: *outputError
+      address: *address
   export:
     name: "Export an account"
     description: "Export an existing account in order to backup it and import it in an other wallet. Respect the Web3 Secret Storage specification. See https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition for more information."
     inputs:
       address: *address
       passphrase: *passphrase
-    outputs:
-      success:
-        name: "Success"
-        description: "Output when the task executes successfully."
-        data: &account
-          address: *address
-          id:
-            name: "ID"
-            description: "The id of the account."
-            type: String
-          version:
-            name: "Version"
-            description: "The version used to export the account."
-            type: Number
-          crypto:
-            name: "Crypto"
-            description: "The encrypted account."
-            type: Object
-      error: *outputError
+    outputs: &account
+      address: *address
+      id:
+        name: "ID"
+        description: "The id of the account."
+        type: String
+      version:
+        name: "Version"
+        description: "The version used to export the account."
+        type: Number
+      crypto:
+        name: "Crypto"
+        description: "The encrypted account."
+        type: Object
   import:
     name: "Import an account"
     description: "Import an account. The account have to respect the Web3 Secret Storage specification. See https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition for more information."
@@ -95,12 +68,7 @@ tasks:
         object: *account
       passphrase: *passphrase
     outputs:
-      success:
-        name: "Success"
-        description: "Output when the task executes successfully."
-        data:
-          address: *address
-      error: *outputError
+      address: *address
   sign:
     name: "Sign transaction"
     description: "Sign a transaction with the specified account."
@@ -141,15 +109,10 @@ tasks:
             description: "The data of the transaction."
             type: String
     outputs:
-      success:
-        name: "Success"
-        description: "Output when the task executes successfully."
-        data:
-          signedTransaction:
-            name: "Signed transaction"
-            description: "The signed transaction."
-            type: String
-      error: *outputError
+      signedTransaction:
+        name: "Signed transaction"
+        description: "The signed transaction."
+        type: String
   importFromPrivateKey:
     name: "Import an account from a private key"
     description: "Import an account from a private key."
@@ -160,9 +123,4 @@ tasks:
         type: String
       passphrase: *passphrase
     outputs:
-      success:
-        name: "Success"
-        description: "Output when the task executes successfully."
-        data:
-          address: *address
-      error: *outputError
+      address: *address

--- a/systemservices/marketplace/mesg.yml
+++ b/systemservices/marketplace/mesg.yml
@@ -14,107 +14,102 @@ tasks:
   listServices:
     inputs:
     outputs:
-      success:
-        data:
-          services: &services
-            type: Object
-            repeated: true
-            object: &service
-              sid: &sid
-                type: String
-              createTime: &createTime
-                type: String
-              owner: &owner
-                type: String
-      error: &outputError
-        name: "Error"
-        description: "Output when an error occurs"
-        data:
-          message:
-            name: "Message"
-            description: "The error message"
+      services: &services
+        type: Object
+        repeated: true
+        object: &service
+          sid: &sid
             type: String
-          code:
-            name: "Error code"
-            description: "The error code"
+          createTime: &createTime
             type: String
-            optional: true
+          owner: &owner
+            type: String
   getService:
     inputs:
       sid: *sid
     outputs:
-      error: *outputError
-      success:
-        data:
-          <<: *service
-          offers: &offers
+      <<: *service
+      offers: &offers
+        type: Object
+        repeated: true
+        optional: true
+        object: &offer
+          offerIndex: &offerIndex
+            type: String
+          price: &price
+            type: String
+          duration: &duration
+            type: String
+          active:
+            type: Boolean
+          createTime: *createTime
+      purchases: &purchases
+        type: Object
+        repeated: true
+        optional: true
+        object: &purchase
+          purchaser: &purchaser
+            type: String
+          expire: &expire
+            type: String
+          createTime: *createTime
+      versions: &versions
+        type: Object
+        repeated: true
+        optional: true
+        object: &version
+          versionHash: &versionHash
+            type: String
+          manifest: &manifest
+            type: String
+          manifestProtocol: &manifestProtocol
+            type: String
+          createTime: *createTime
+          manifestData: &manifestData
             type: Object
-            repeated: true
             optional: true
-            object: &offer
-              offerIndex: &offerIndex
+            object:
+              version:
                 type: String
-              price: &price
-                type: String
-              duration: &duration
-                type: String
-              active:
-                type: Boolean
-              createTime: *createTime
-          purchases: &purchases
-            type: Object
-            repeated: true
-            optional: true
-            object: &purchase
-              purchaser: &purchaser
-                type: String
-              expire: &expire
-                type: String
-              createTime: *createTime
-          versions: &versions
-            type: Object
-            repeated: true
-            optional: true
-            object: &version
-              versionHash: &versionHash
-                type: String
-              manifest: &manifest
-                type: String
-              manifestProtocol: &manifestProtocol
-                type: String
-              createTime: *createTime
-              manifestData: &manifestData
+              service: &manifestServiceData
                 type: Object
-                optional: true
                 object:
-                  version:
-                    type: String
-                  service: &manifestServiceData
+                  deployment:
                     type: Object
                     object:
-                      deployment:
+                      type:
+                        type: String
+                      source:
+                        type: String
+                  definition:
+                    type: Object
+                    object:
+                      hash:
+                        type: String
+                      sid:
+                        type: String
+                      name:
+                        type: String
+                      description:
+                        type: String
+                        optional: true
+                      tasks:
                         type: Object
+                        repeated: true
+                        optional: true
                         object:
-                          type:
-                            type: String
-                          source:
-                            type: String
-                      definition:
-                        type: Object
-                        object:
-                          hash:
-                            type: String
-                          sid:
+                          key:
                             type: String
                           name:
                             type: String
+                            optional: true
                           description:
                             type: String
                             optional: true
-                          tasks:
+                          inputs: &manifestServiceDataParameters
                             type: Object
-                            repeated: true
                             optional: true
+                            repeated: true
                             object:
                               key:
                                 type: String
@@ -124,47 +119,20 @@ tasks:
                               description:
                                 type: String
                                 optional: true
-                              inputs: &manifestServiceDataParameters
+                              type:
+                                type: String
+                              optional:
+                                type: Boolean
+                                optional: true
+                              repeated:
+                                type: Boolean
+                                optional: true
+                              object:
                                 type: Object
                                 optional: true
-                                repeated: true
-                                object:
-                                  key:
-                                    type: String
-                                  name:
-                                    type: String
-                                    optional: true
-                                  description:
-                                    type: String
-                                    optional: true
-                                  type:
-                                    type: String
-                                  optional:
-                                    type: Boolean
-                                    optional: true
-                                  repeated:
-                                    type: Boolean
-                                    optional: true
-                                  object:
-                                    type: Object
-                                    optional: true
-                              outputs:
-                                type: Object
-                                repeated: true
-                                object:
-                                  key:
-                                    type: String
-                                  name:
-                                    type: String
-                                    optional: true
-                                  description:
-                                    type: String
-                                    optional: true
-                                  data: *manifestServiceDataParameters
-                          events:
+                          outputs:
                             type: Object
                             repeated: true
-                            optional: true
                             object:
                               key:
                                 type: String
@@ -175,45 +143,59 @@ tasks:
                                 type: String
                                 optional: true
                               data: *manifestServiceDataParameters
-                          configuration:
-                            type: Object
-                            optional: true
-                            object: &manifestServiceDataConfiguration
-                              volumes:
-                                type: String
-                                repeated: true
-                                optional: true
-                              volumesFrom:
-                                type: String
-                                repeated: true
-                                optional: true
-                              ports:
-                                type: String
-                                repeated: true
-                                optional: true
-                              args:
-                                type: String
-                                repeated: true
-                                optional: true
-                              command:
-                                type: String
-                                optional: true
-                          dependencies:
-                            type: Object
-                            repeated: true
-                            optional: true
-                            object:
-                              <<: *manifestServiceDataConfiguration
-                              key:
-                                type: String
-                              image:
-                                type: String
-                          repository:
+                      events:
+                        type: Object
+                        repeated: true
+                        optional: true
+                        object:
+                          key:
+                            type: String
+                          name:
                             type: String
                             optional: true
-                      readme:
+                          description:
+                            type: String
+                            optional: true
+                          data: *manifestServiceDataParameters
+                      configuration:
+                        type: Object
+                        optional: true
+                        object: &manifestServiceDataConfiguration
+                          volumes:
+                            type: String
+                            repeated: true
+                            optional: true
+                          volumesFrom:
+                            type: String
+                            repeated: true
+                            optional: true
+                          ports:
+                            type: String
+                            repeated: true
+                            optional: true
+                          args:
+                            type: String
+                            repeated: true
+                            optional: true
+                          command:
+                            type: String
+                            optional: true
+                      dependencies:
+                        type: Object
+                        repeated: true
+                        optional: true
+                        object:
+                          <<: *manifestServiceDataConfiguration
+                          key:
+                            type: String
+                          image:
+                            type: String
+                      repository:
                         type: String
                         optional: true
+                  readme:
+                    type: String
+                    optional: true
   preparePublishServiceVersion:
     inputs:
       service: *manifestServiceData
@@ -225,50 +207,44 @@ tasks:
       gasPrice: &inputGasPrice
         type: String
         optional: true
-    outputs:
-      error: *outputError
-      success: &outputTransaction
-        data: &transaction
-          chainID:
-            name: "Chain ID"
-            description: "The ID of the chain the transaction is for. See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids."
-            type: Number
-          nonce:
-            name: "Nonce"
-            description: "Nonce to use."
-            type: Number
-          to:
-            name: "To"
-            description: "The to address."
-            type: String
-          value:
-            name: "Value"
-            description: "The value in Wei."
-            type: String
-          gas:
-            name: "Gas"
-            description: "The maximum gas to use to execute this transaction"
-            type: Number
-          gasPrice:
-            name: "Gas price"
-            description: "The gas price in Wei."
-            type: String
-          data:
-            name: "Data"
-            description: "The data of the transaction."
-            type: String
+    outputs: &transaction
+      chainID:
+        name: "Chain ID"
+        description: "The ID of the chain the transaction is for. See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids."
+        type: Number
+      nonce:
+        name: "Nonce"
+        description: "Nonce to use."
+        type: Number
+      to:
+        name: "To"
+        description: "The to address."
+        type: String
+      value:
+        name: "Value"
+        description: "The value in Wei."
+        type: String
+      gas:
+        name: "Gas"
+        description: "The maximum gas to use to execute this transaction"
+        type: Number
+      gasPrice:
+        name: "Gas price"
+        description: "The gas price in Wei."
+        type: String
+      data:
+        name: "Data"
+        description: "The data of the transaction."
+        type: String
   publishPublishServiceVersion:
     inputs:
       signedTransaction: &signedTransaction
         type: String
     outputs:
-      error: *outputError
-      success:
-        data:
-          sid: *sid
-          versionHash: *versionHash
-          manifest: *manifest
-          manifestProtocol: *manifestProtocol
+      sid: *sid
+      versionHash: *versionHash
+      manifest: *manifest
+      manifestProtocol: *manifestProtocol
   prepareCreateServiceOffer:
     inputs:
       sid: *sid
@@ -278,19 +254,15 @@ tasks:
       gas: *inputGas
       gasPrice: *inputGasPrice
     outputs:
-      error: *outputError
-      success: *outputTransaction
+      <<: *transaction
   publishCreateServiceOffer:
     inputs:
       signedTransaction: *signedTransaction
     outputs:
-      error: *outputError
-      success:
-        data:
-          sid: *sid
-          offerIndex: *offerIndex
-          price: *price
-          duration: *duration
+      sid: *sid
+      offerIndex: *offerIndex
+      price: *price
+      duration: *duration
   preparePurchase:
     inputs:
       sid: *sid
@@ -299,28 +271,22 @@ tasks:
       gas: *inputGas
       gasPrice: *inputGasPrice
     outputs:
-      error: *outputError
-      success:
-        data:
-          transactions:
-            repeated: true
-            type: Object
-            object: *transaction
+      transactions:
+        repeated: true
+        type: Object
+        object: *transaction
   publishPurchase:
     inputs:
       signedTransactions:
         <<: *signedTransaction
         repeated: true
     outputs:
-      error: *outputError
-      success:
-        data:
-          sid: *sid
-          offerIndex: *offerIndex
-          purchaser: *purchaser
-          price: *price
-          duration: *duration
-          expire: *expire
+      sid: *sid
+      offerIndex: *offerIndex
+      purchaser: *purchaser
+      price: *price
+      duration: *duration
+      expire: *expire
   isAuthorized:
     inputs:
       sid:
@@ -333,18 +299,15 @@ tasks:
         repeated: true
         type: String
     outputs:
-      error: *outputError
-      success:
-        data:
-          authorized:
-            type: Boolean
-          sid: *sid
-          source:
-            type: String
-            optional: true
-          type:
-            type: String
-            optional: true
+      authorized:
+        type: Boolean
+      sid: *sid
+      source:
+        type: String
+        optional: true
+      type:
+        type: String
+        optional: true
 events:
   serviceCreated:
     data:

--- a/systemservices/marketplace/package-lock.json
+++ b/systemservices/marketplace/package-lock.json
@@ -16,9 +16,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.41.tgz",
-          "integrity": "sha512-sPZWEbFMz6qAy9SLY7jh5cgepmsiwqUUHjvEm8lpU6kug2hmmcyuTnwhoGw/GWpI5Npue4EqvsiQQI0eWjW/ZA=="
+          "version": "9.6.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.48.tgz",
+          "integrity": "sha512-velR2CyDrHC1WFheHr5Jm25mdCMs0BXJRp6u0zf8PF9yeOy4Xff5sJeusWS7xOmhAoezlSq8LJ0+9M5H7YkTdw=="
         }
       }
     },
@@ -101,9 +101,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.120",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.120.tgz",
-      "integrity": "sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw=="
+      "version": "4.14.129",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.129.tgz",
+      "integrity": "sha512-oYaV0eSlnOacOr7i4X1FFdH8ttSlb57gu3I9MuStIv2CYkISEY84dNHYsC3bF6sNH7qYcu1BtVrCtQ8Q4KPTfQ=="
     },
     "@types/long": {
       "version": "4.0.0",
@@ -2660,14 +2660,14 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "grpc": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.18.0.tgz",
-      "integrity": "sha512-M0K67Zhv2ZzCjrTbQvjWgYFPB929L+qAVnbNgXepbfO5kJxUYc30dP8m8vb+o8QdahLHAeYfIqRoIzZRcCB98Q==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.20.3.tgz",
+      "integrity": "sha512-GsEsi0NVj6usS/xor8pF/xDbDiwZQR59aZl5NUZ59Sy2bdPQFZ3UePr5wevZjHboirRCIQCKRI1cCgvSWUe2ag==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
-        "nan": "^2.0.0",
-        "node-pre-gyp": "^0.12.0",
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.13.0",
         "protobufjs": "^5.0.3"
       },
       "dependencies": {
@@ -2723,13 +2723,6 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true
@@ -2765,18 +2758,6 @@
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1",
             "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -2844,7 +2825,7 @@
           }
         },
         "minizlib": {
-          "version": "1.1.1",
+          "version": "1.2.1",
           "bundled": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2863,21 +2844,35 @@
             }
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         },
         "needle": {
-          "version": "2.2.4",
+          "version": "2.3.1",
           "bundled": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            }
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.13.0",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -2901,11 +2896,11 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.1.12",
+          "version": "1.4.1",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -2996,10 +2991,24 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
           }
         },
         "safe-buffer": {
@@ -3015,7 +3024,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.6.0",
+          "version": "5.7.0",
           "bundled": true
         },
         "set-blocking": {
@@ -3745,9 +3754,9 @@
       "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA="
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4046,9 +4055,8 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "mesg-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-2.0.1.tgz",
-      "integrity": "sha512-UqApC/fICS5mTtlnu3MEY8HgA2OO2pna++Gv698Fs634p6U3B8IOHJfdIyoBswRXYmc8LUyGjM3m2VX/CpnoqA==",
+      "version": "github:mesg-foundation/mesg-js#ddd6a45ebe417f4c2d4c79483940736e77c9e6ce",
+      "from": "github:mesg-foundation/mesg-js#next",
       "requires": {
         "@grpc/proto-loader": "^0.3.0",
         "clone": "^2.1.2",

--- a/systemservices/marketplace/package.json
+++ b/systemservices/marketplace/package.json
@@ -8,7 +8,7 @@
     "bignumber.js": "^8.1.1",
     "ipfs-http-client": "^30.1.3",
     "jsonschema": "^1.2.4",
-    "mesg-js": "^2.0.1",
+    "mesg-js": "github:mesg-foundation/mesg-js#next",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "web3": "1.0.0-beta.37"


### PR DESCRIPTION
Remove the outputs from the definitions of the system service in order to have the core that can start.

I just removed all `error` outputs and returned the data of the previous `success` output