### PR TITLE
Remove lib for debug for the marketplace

### DIFF
--- a/systemservices/marketplace/package-lock.json
+++ b/systemservices/marketplace/package-lock.json
@@ -6608,7 +6608,8 @@
     },
     "web3-providers-http": {
       "version": "1.0.0-beta.37",
-      "resolved": "git+https://github.com/NicolasMahe/web3-providers-http.git#4257b409ec0461164749ef95d1c41b39b7e5e011",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz",
+      "integrity": "sha512-FM/1YDB1jtZuTo78habFj7S9tNHoqt0UipdyoQV29b8LkGKZV9Vs3is8L24hzuj1j/tbwkcAH+ewIseHwu0DTg==",
       "requires": {
         "web3-core-helpers": "1.0.0-beta.37",
         "xhr2-cookies": "1.1.0"

--- a/systemservices/marketplace/package.json
+++ b/systemservices/marketplace/package.json
@@ -11,8 +11,7 @@
     "mesg-js": "^3.0.0-beta.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
-    "web3": "1.0.0-beta.37",
-    "web3-providers-http": "git+https://github.com/NicolasMahe/web3-providers-http.git"
+    "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
     "@types/node": "^10.14.4",


### PR DESCRIPTION
We used a lib with some logs to try to identify an issue possibly with web3 but the issue is not related to web3 so this PR reverts it