### PR TITLE
Fix the mesg folder mount from /home/root to /root

### DIFF
--- a/dev
+++ b/dev
@@ -94,7 +94,7 @@ docker service create \
   --name engine \
   --tty \
   --label com.docker.stack.namespace=engine --label com.docker.stack.image=mesg/engine:$VERSION \
-  --mount type=bind,source=/var/run/docker.sock,destination=/var/run/docker.sock --mount type=bind,source=$HOME/.mesg,destination=/home/root/.mesg \
+  --mount type=bind,source=/var/run/docker.sock,destination=/var/run/docker.sock --mount type=bind,source=$HOME/.mesg,destination=/root/.mesg \
   --network engine --publish 50052:50052 \
   mesg/engine:$VERSION
 


### PR DESCRIPTION
I just find a bug in the PR https://github.com/mesg-foundation/engine/pull/1032, it was mounting the folder in docker in `/home/root` instead of `/root`.

Please, delete your local .mesg folder, start the engine (`./dev`) and check if the`.mesg` has been recreated and contains the databases