### PR TITLE
Separate unit tests and integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,9 @@ jobs:
       - run: go mod download
       - <<: *save_go_mod_cache
       - run: mkdir -p ~/.mesg
-      - <<: *restore_go_cache
+      # - <<: *restore_go_cache
       - run: go test -v -timeout 300s -p 1 -tags=integration -coverprofile=coverage.txt ./...
-      - <<: *save_go_cache
+      # - <<: *save_go_cache
       - run: bash <(curl -s https://codecov.io/bash)
 
   "lint":
@@ -80,9 +80,9 @@ jobs:
       - <<: *restore_go_mod_cache
       - run: go mod download
       - <<: *save_go_mod_cache
-      - <<: *restore_go_cache
+      # - <<: *restore_go_cache
       - run: golangci-lint run
-      - <<: *save_go_cache
+      # - <<: *save_go_cache
 
   "publish_docker_dev":
     <<: *run_on_machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,7 @@ jobs:
       - run: go mod download
       - <<: *save_go_mod_cache
       - run: mkdir -p ~/.mesg
-      - run: go test -v -timeout 300s -p 1 -tags=integration -coverprofile=coverage.txt ./...
-      - run: bash <(curl -s https://codecov.io/bash)
+      - run: go test -v -timeout 300s -p 1 -tags=integration ./...
 
   "lint":
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,9 @@ jobs:
       - <<: *save_go_mod_cache
       - run: mkdir -p ~/.mesg
       - <<: *restore_go_cache
-      - run: go test -v -timeout 300s ./...
+      - run: go test -v -timeout 300s -coverprofile=coverage.txt ./...
       - <<: *save_go_cache
+      - run: bash <(curl -s https://codecov.io/bash)
 
   "test_integration":
     <<: *run_on_docker
@@ -65,9 +66,7 @@ jobs:
       - run: go mod download
       - <<: *save_go_mod_cache
       - run: mkdir -p ~/.mesg
-      # - <<: *restore_go_cache
       - run: go test -v -timeout 300s -p 1 -tags=integration -coverprofile=coverage.txt ./...
-      # - <<: *save_go_cache
       - run: bash <(curl -s https://codecov.io/bash)
 
   "lint":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,22 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: docker swarm init
+      - <<: *restore_go_mod_cache
+      - run: go mod download
+      - <<: *save_go_mod_cache
+      - run: mkdir -p ~/.mesg
+      - <<: *restore_go_cache
+      - run: go test -v -timeout 300s ./...
+      - <<: *save_go_cache
+
+  "test_integration":
+    <<: *run_on_docker
+    environment:
+      - GOCACHE: *go_cache_dir
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: docker swarm init
       - run: docker build -t sleep docker-images/sleep/
       - run: docker build -t http-server docker-images/http-server/
       - <<: *restore_go_mod_cache
@@ -99,6 +115,14 @@ workflows:
                 - "dev"
                 - "master"
       - "test":
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              ignore:
+                - "dev"
+                - "master"
+      - "test_integration":
           filters:
             tags:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,7 @@ jobs:
       - <<: *restore_go_mod_cache
       - run: go mod download
       - <<: *save_go_mod_cache
-      # - <<: *restore_go_cache
       - run: golangci-lint run
-      # - <<: *save_go_cache
 
   "publish_docker_dev":
     <<: *run_on_machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,14 +143,27 @@ workflows:
               ignore: /.*/
             branches:
               only: dev
+      - "test_integration":
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: dev
       - "publish_docker_dev":
           requires:
             - "test"
+            - "test_integration"
             - "lint"
 
   test_prod:
     jobs:
       - "test":
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: master
+      - "test_integration":
           filters:
             tags:
               ignore: /.*/
@@ -177,10 +190,17 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+      - "test_integration":
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - "publish_docker_prod":
           requires:
             - "test"
             - "lint"
+            - "test_integration"
           filters:
             tags:
               only: /^v.*/

--- a/server/grpc/core/core_integration_test.go
+++ b/server/grpc/core/core_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package core
 
 import (

--- a/server/grpc/service/service_integration_test.go
+++ b/server/grpc/service/service_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package service
 
 import (


### PR DESCRIPTION
This PR separate integration test from unit test on CircleCI.
The unit test runs in only 8sec 🍾 
The code coverage is now only based on the unit tests. (that's why there is -5% of code coverage)

The ultimate thing to do about integration test is to transform it to a workflow that uses an application and a service to test many situation once.
I recommend to keep integration test until then.