### PR TITLE
update marketplace dependencies

### DIFF
--- a/systemservices/marketplace/package-lock.json
+++ b/systemservices/marketplace/package-lock.json
@@ -16,9 +16,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.48",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.48.tgz",
-          "integrity": "sha512-velR2CyDrHC1WFheHr5Jm25mdCMs0BXJRp6u0zf8PF9yeOy4Xff5sJeusWS7xOmhAoezlSq8LJ0+9M5H7YkTdw=="
+          "version": "9.6.49",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.49.tgz",
+          "integrity": "sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA=="
         }
       }
     },
@@ -101,9 +101,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.132",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.132.tgz",
-      "integrity": "sha512-RNUU1rrh85NgUJcjOOr96YXr+RHwInGbaQCZmlitqOaCKXffj8bh+Zxwuq5rjDy5OgzFldDVoqk4pyLEDiwxIw=="
+      "version": "4.14.134",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
+      "integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw=="
     },
     "@types/long": {
       "version": "4.0.0",
@@ -111,9 +111,9 @@
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/node": {
-      "version": "10.14.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
-      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
+      "version": "10.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+      "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw=="
     },
     "@types/request": {
       "version": "2.48.1",
@@ -128,9 +128,9 @@
       }
     },
     "@types/request-promise-native": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.15.tgz",
-      "integrity": "sha512-uYPjTChD9TpjlvbBjNpZfNc64TBejBS52u7pbxhQLnlxw+5Em7wLb6DU2wdJVhJ2Mou7v50N0qgL4Gia5mmRYg==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.16.tgz",
+      "integrity": "sha512-gbLf6cg1XGBU8BObOgs5VkCQo5JFz2GstgZjyE4FRbig/jiCEdiynu2fCzJlw3qYPuoj59spKnvuRLN4PsMvhA==",
       "dev": true,
       "requires": {
         "@types/request": "*"
@@ -564,6 +564,14 @@
         "string-width": "^2.0.0",
         "term-size": "^1.2.0",
         "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -775,10 +783,9 @@
       }
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -803,9 +810,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
-      "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -1001,9 +1008,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -1184,9 +1191,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -1988,9 +1995,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
-      "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2255,9 +2262,9 @@
           "optional": true
         },
         "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
           "dev": true,
           "optional": true
         },
@@ -2543,9 +2550,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -3179,6 +3186,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hi-base32": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.0.tgz",
+      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3302,18 +3314,31 @@
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "ipfs-block": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.0.tgz",
-      "integrity": "sha512-znNtFRxXlJYP1/Q4u0tGFJUceH9pNww8WA+zair6T3y7d28m+vtUDJGn96M7ZlFFSkByQyQsAiq2ssNhKtMzxw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
+      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
       "requires": {
-        "cids": "~0.5.5",
+        "cids": "~0.7.0",
         "class-is": "^1.1.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
+          "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14"
+          }
+        }
       }
     },
     "ipfs-http-client": {
-      "version": "30.1.3",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-30.1.3.tgz",
-      "integrity": "sha512-NQ7WTLKUZeoKaKXrTSLAtjASRYCR0bPdsolZf16Y7Gt7o3RfiPpFF+AqvP0xbekOV3/zhFj2Qyf6ShEV4CCtsQ==",
+      "version": "30.1.4",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-30.1.4.tgz",
+      "integrity": "sha512-ordvoPT3lAFL5qsvdYBeDGRP03gtbL6Jl+qJ9dztyhE7NJf2yhtnU3ZNqN1JMCcUK0qpGsDzX89t8dKQvI80Pw==",
       "requires": {
         "async": "^2.6.1",
         "bignumber.js": "^8.0.2",
@@ -3350,7 +3375,7 @@
         "promisify-es6": "^1.0.3",
         "pull-defer": "~0.2.3",
         "pull-stream": "^3.6.9",
-        "pull-to-stream": "~0.1.0",
+        "pull-to-stream": "~0.1.1",
         "pump": "^3.0.0",
         "qs": "^6.5.2",
         "readable-stream": "^3.1.1",
@@ -3368,9 +3393,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -3378,9 +3403,9 @@
           }
         },
         "tar-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.0.1.tgz",
-          "integrity": "sha512-I6OJF7wE62BC6zNPdHDtseK0D0187PBjbKSLYY4ffvVkBM6tyBn2O9plDvVM2229/mozfEL/X3++qSvYYQE2xw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+          "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
           "requires": {
             "bl": "^3.0.0",
             "end-of-stream": "^1.4.1",
@@ -3571,16 +3596,29 @@
       }
     },
     "is-ipfs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.0.tgz",
-      "integrity": "sha512-q/CO69rN+vbw9eGXGQOAa15zXq+pSyhdKvE7mqvuplDu67LyT3H9t3RyYQvKpueN7dL4f6fbyjEMPp9J3rJ4qA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.1.tgz",
+      "integrity": "sha512-WhqQylam6pODS2RyqT/u0PR5KWtBZNCgPjgargFOVQjzw/3+6d0midXenzU65klM4LH13IUiCC6ObhDUdXZ7Nw==",
       "requires": {
         "bs58": "^4.0.1",
-        "cids": "~0.5.6",
-        "mafmt": "^v6.0.7",
+        "cids": "~0.7.0",
+        "mafmt": "^6.0.7",
         "multiaddr": "^6.0.4",
         "multibase": "~0.6.0",
         "multihashes": "~0.4.13"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
+          "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14"
+          }
+        }
       }
     },
     "is-natural-number": {
@@ -3712,9 +3750,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -4055,14 +4093,14 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "mesg-js": {
-      "version": "3.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-3.0.0-beta.0.tgz",
-      "integrity": "sha512-n/EaOHpogTFJRCr/5gCzFhFBPHFXHX4k4AWHHaZjOEsO/tLSWnJJ03tWupJ6EsXNjNjj0jp9n7qQdzfGfXkfdg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-3.0.0.tgz",
+      "integrity": "sha512-mAqQtLMonpoINjunsmdn2ik4sAygDYEcOoHe8rnAdytbPt9bEP1VeLnK3M7LmqCZZJ+D+0zVpl5ma1sCIaxoeQ==",
       "requires": {
         "@grpc/proto-loader": "^0.3.0",
         "clone": "^2.1.2",
-        "grpc": "^1.13.0",
-        "js-yaml": "^3.12.0",
+        "grpc": "^1.21.1",
+        "js-yaml": "^3.13.1",
         "uuid": "^3.3.2"
       }
     },
@@ -4221,12 +4259,13 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multiaddr": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.0.6.tgz",
-      "integrity": "sha512-nR4s91mi7IKed1jrqUj/4OhZ1VKdAjUG79IuVB5PS6b+qxOZLKPW8nsskHhrfGn4o1Rn1NJWl7znidF/NVQpEA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
+      "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
       "requires": {
         "bs58": "^4.0.1",
         "class-is": "^1.1.0",
+        "hi-base32": "~0.5.0",
         "ip": "^1.1.5",
         "is-ip": "^2.0.0",
         "varint": "^5.0.0"
@@ -4251,9 +4290,9 @@
       }
     },
     "multicodec": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.0.tgz",
-      "integrity": "sha512-lKsJeT4cKeSq0rVEWhO3oSBgDN4sMY1sNZKlvl68g/ZAahjPS1KIVyF4IqhuYmCdtOyKs4Q4hQ6M0C3iqRnuqQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.3.tgz",
+      "integrity": "sha512-TUId9mavSh7q4ui5nUYiC0U10XVrMhsoMLPoG6nAAaFt2GKqZKK3aB2AeFk58aqEnLhmTSdRkmNrlty4jjOxzg==",
       "requires": {
         "varint": "^5.0.0"
       }
@@ -4366,9 +4405,9 @@
       }
     },
     "nodemon": {
-      "version": "1.18.11",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.11.tgz",
-      "integrity": "sha512-KdN3tm1zkarlqNo4+W9raU3ihM4H15MVMSE/f9rYDZmFgDHAfAJsomYrHhApAkuUemYjFyEeXlpCOQ2v5gtBEw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.1.tgz",
+      "integrity": "sha512-/DXLzd/GhiaDXXbGId5BzxP1GlsqtMGM9zTmkWrgXtSqjKmGSbLicM/oAy4FR0YWm14jCHRwnR31AHS2dYFHrg==",
       "dev": true,
       "requires": {
         "chokidar": "^2.1.5",
@@ -4393,9 +4432,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -4855,9 +4894,9 @@
       "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "pstree.remy": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
-      "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
+      "integrity": "sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A==",
       "dev": true
     },
     "public-encrypt": {
@@ -4879,22 +4918,22 @@
       "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
     },
     "pull-stream": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
-      "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+      "version": "3.6.12",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.12.tgz",
+      "integrity": "sha512-+LO1XIVyTMmeoH26UHznpgrgX2npTVYccTkMpgk/EyiQjFt1FmoNm+w+/zMLuz9U3bpvT5sSUicMKEe/2JjgEA=="
     },
     "pull-to-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.0.tgz",
-      "integrity": "sha512-LMvdE0JwT7XQZMFjc7JDl/G9gmoZ8Zo8e86SG4ZZUcjuwvod803KxpAK8WrmdxzHsMRK9DETlIzuA0tbEVv6jg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.1.tgz",
+      "integrity": "sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==",
       "requires": {
         "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -5219,18 +5258,25 @@
       }
     },
     "secp256k1": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.2.tgz",
-      "integrity": "sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
       "requires": {
-        "bindings": "^1.2.1",
-        "bip66": "^1.1.3",
-        "bn.js": "^4.11.3",
-        "create-hash": "^1.1.2",
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
-        "elliptic": "^6.2.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
+        "elliptic": "^6.4.1",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "seek-bzip": {
@@ -5596,9 +5642,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -5786,12 +5832,12 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },
@@ -6000,9 +6046,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "typescript-json-schema": {
@@ -6769,9 +6815,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -6879,11 +6925,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",

--- a/systemservices/marketplace/package.json
+++ b/systemservices/marketplace/package.json
@@ -6,21 +6,21 @@
   "dependencies": {
     "base-x": "^3.0.5",
     "bignumber.js": "^8.1.1",
-    "ipfs-http-client": "^30.1.3",
+    "ipfs-http-client": "^30.1.4",
     "jsonschema": "^1.2.4",
-    "mesg-js": "^3.0.0-beta.0",
+    "mesg-js": "^3.0.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
-    "@types/node": "^10.14.4",
+    "@types/node": "^10.14.8",
     "@types/request": "^2.48.1",
-    "@types/request-promise-native": "^1.0.15",
+    "@types/request-promise-native": "^1.0.16",
     "@types/web3": "^1.0.18",
-    "nodemon": "^1.18.11",
+    "nodemon": "^1.19.1",
     "ts-node": "^7.0.1",
-    "typescript": "^3.3.3333",
+    "typescript": "^3.5.1",
     "typescript-json-schema": "^0.36.0"
   },
   "scripts": {


### PR DESCRIPTION
Update the marketplace service dependencies to mainly use the mesg-js v3.0.0 instead of the beta and fixing security issues: https://github.com/mesg-foundation/engine/network/alerts