### PR TITLE
Marketplace backward compatibility

### DIFF
--- a/sdk/deploy_test.go
+++ b/sdk/deploy_test.go
@@ -168,7 +168,7 @@ func TestDeployInvalidService(t *testing.T) {
 
 func TestDeployServiceFromURL(t *testing.T) {
 	var (
-		url   = "git://github.com/mesg-foundation/service-webhook#single-outputs"
+		url   = "git://github.com/mesg-foundation/service-webhook"
 		a, at = newTesting(t)
 	)
 	defer at.close()

--- a/server/grpc/core/core_integration_test.go
+++ b/server/grpc/core/core_integration_test.go
@@ -32,7 +32,7 @@ func TestGetService(t *testing.T) {
 }
 
 func TestListServices(t *testing.T) {
-	url := "git://github.com/mesg-foundation/service-webhook#single-outputs"
+	url := "git://github.com/mesg-foundation/service-webhook"
 	server, closer := newServer(t)
 	defer closer()
 

--- a/server/grpc/core/deploy_integration_test.go
+++ b/server/grpc/core/deploy_integration_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestIntegrationDeployService(t *testing.T) {
-	url := "git://github.com/mesg-foundation/service-webhook#single-outputs"
+	url := "git://github.com/mesg-foundation/service-webhook"
 
 	server, closer := newServer(t)
 	defer closer()

--- a/server/grpc/core/deploy_test.go
+++ b/server/grpc/core/deploy_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDeployService(t *testing.T) {
-	url := "git://github.com/mesg-foundation/service-webhook#single-outputs"
+	url := "git://github.com/mesg-foundation/service-webhook"
 
 	server, dt, closer := newServerAndDockerTest(t)
 	defer closer()

--- a/systemservices/marketplace/mesg.yml
+++ b/systemservices/marketplace/mesg.yml
@@ -121,6 +121,7 @@ tasks:
                                 optional: true
                               type:
                                 type: String
+                                optional: true
                               optional:
                                 type: Boolean
                                 optional: true


### PR DESCRIPTION
just by making the type attribute optional, both version of services from 0.9 and 0.10 can be returned from the service