### PR TITLE
Sdk dependency rearrangement

### DIFF
--- a/sdk/event/event.go
+++ b/sdk/event/event.go
@@ -2,9 +2,9 @@ package eventsdk
 
 import (
 	"github.com/cskr/pubsub"
-	"github.com/mesg-foundation/core/database"
 	"github.com/mesg-foundation/core/event"
 	"github.com/mesg-foundation/core/hash"
+	servicesdk "github.com/mesg-foundation/core/sdk/service"
 )
 
 const (
@@ -15,21 +15,21 @@ const (
 
 // Event exposes event APIs of MESG.
 type Event struct {
-	ps        *pubsub.PubSub
-	serviceDB database.ServiceDB
+	ps      *pubsub.PubSub
+	service *servicesdk.Service
 }
 
 // New creates a new Event SDK with given options.
-func New(ps *pubsub.PubSub, serviceDB database.ServiceDB) *Event {
+func New(ps *pubsub.PubSub, service *servicesdk.Service) *Event {
 	return &Event{
-		ps:        ps,
-		serviceDB: serviceDB,
+		ps:      ps,
+		service: service,
 	}
 }
 
 // Emit emits a MESG event eventKey with eventData for service token.
 func (e *Event) Emit(serviceHash hash.Hash, eventKey string, eventData map[string]interface{}) error {
-	s, err := e.serviceDB.Get(serviceHash)
+	s, err := e.service.Get(serviceHash)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (e *Event) GetStream(f *Filter) *Listener {
 
 // Listen listens events matches with eventFilter on serviceID.
 func (e *Event) Listen(serviceHash hash.Hash, f *Filter) (*Listener, error) {
-	s, err := e.serviceDB.Get(serviceHash)
+	s, err := e.service.Get(serviceHash)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/event/event.go
+++ b/sdk/event/event.go
@@ -15,21 +15,21 @@ const (
 
 // Event exposes event APIs of MESG.
 type Event struct {
-	ps *pubsub.PubSub
-	db database.ServiceDB
+	ps        *pubsub.PubSub
+	serviceDB database.ServiceDB
 }
 
 // New creates a new Event SDK with given options.
-func New(ps *pubsub.PubSub, db database.ServiceDB) *Event {
+func New(ps *pubsub.PubSub, serviceDB database.ServiceDB) *Event {
 	return &Event{
-		ps: ps,
-		db: db,
+		ps:        ps,
+		serviceDB: serviceDB,
 	}
 }
 
 // Emit emits a MESG event eventKey with eventData for service token.
 func (e *Event) Emit(serviceHash hash.Hash, eventKey string, eventData map[string]interface{}) error {
-	s, err := e.db.Get(serviceHash)
+	s, err := e.serviceDB.Get(serviceHash)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (e *Event) GetStream(f *Filter) *Listener {
 
 // Listen listens events matches with eventFilter on serviceID.
 func (e *Event) Listen(serviceHash hash.Hash, f *Filter) (*Listener, error) {
-	s, err := e.db.Get(serviceHash)
+	s, err := e.serviceDB.Get(serviceHash)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/execution/execution.go
+++ b/sdk/execution/execution.go
@@ -19,19 +19,19 @@ const (
 
 // Execution exposes execution APIs of MESG.
 type Execution struct {
-	ps     *pubsub.PubSub
-	db     database.ServiceDB
-	execDB database.ExecutionDB
-	instDB database.InstanceDB
+	ps        *pubsub.PubSub
+	serviceDB database.ServiceDB
+	execDB    database.ExecutionDB
+	instDB    database.InstanceDB
 }
 
 // New creates a new Execution SDK with given options.
-func New(ps *pubsub.PubSub, db database.ServiceDB, execDB database.ExecutionDB, instDB database.InstanceDB) *Execution {
+func New(ps *pubsub.PubSub, serviceDB database.ServiceDB, execDB database.ExecutionDB, instDB database.InstanceDB) *Execution {
 	return &Execution{
-		ps:     ps,
-		db:     db,
-		execDB: execDB,
-		instDB: instDB,
+		ps:        ps,
+		serviceDB: serviceDB,
+		execDB:    execDB,
+		instDB:    instDB,
 	}
 }
 
@@ -109,7 +109,7 @@ func (e *Execution) validateExecutionOutput(serviceHash hash.Hash, taskKey strin
 		return nil, fmt.Errorf("invalid output: %s", err)
 	}
 
-	s, err := e.db.Get(serviceHash)
+	s, err := e.serviceDB.Get(serviceHash)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (e *Execution) validateExecutionOutput(serviceHash hash.Hash, taskKey strin
 
 // Execute executes a task tasKey with inputData and tags for service serviceID.
 func (e *Execution) Execute(serviceHash hash.Hash, taskKey string, inputData map[string]interface{}, tags []string) (executionHash hash.Hash, err error) {
-	s, err := e.db.Get(serviceHash)
+	s, err := e.serviceDB.Get(serviceHash)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (e *Execution) Execute(serviceHash hash.Hash, taskKey string, inputData map
 
 // Listen listens executions on service.
 func (e *Execution) Listen(serviceHash hash.Hash, f *Filter) (*Listener, error) {
-	s, err := e.db.Get(serviceHash)
+	s, err := e.serviceDB.Get(serviceHash)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/execution/execution_test.go
+++ b/sdk/execution/execution_test.go
@@ -92,7 +92,7 @@ func TestGetsream(t *testing.T) {
 	exec.Status = execution.InProgress
 
 	require.NoError(t, sdk.execDB.Save(exec))
-	require.NoError(t, sdk.db.Save(testService))
+	require.NoError(t, sdk.serviceDB.Save(testService))
 
 	stream := sdk.GetStream(nil)
 	defer stream.Close()

--- a/sdk/instance/instance.go
+++ b/sdk/instance/instance.go
@@ -11,21 +11,22 @@ import (
 	"github.com/mesg-foundation/core/database"
 	"github.com/mesg-foundation/core/hash"
 	"github.com/mesg-foundation/core/instance"
+	servicesdk "github.com/mesg-foundation/core/sdk/service"
 	"github.com/mesg-foundation/core/x/xos"
 )
 
 // Instance exposes service instance APIs of MESG.
 type Instance struct {
 	container  container.Container
-	serviceDB  database.ServiceDB
+	service    *servicesdk.Service
 	instanceDB database.InstanceDB
 }
 
 // New creates a new Instance SDK with given options.
-func New(c container.Container, serviceDB database.ServiceDB, instanceDB database.InstanceDB) *Instance {
+func New(c container.Container, service *servicesdk.Service, instanceDB database.InstanceDB) *Instance {
 	return &Instance{
 		container:  c,
-		serviceDB:  serviceDB,
+		service:    service,
 		instanceDB: instanceDB,
 	}
 }
@@ -51,7 +52,7 @@ func (i *Instance) List(f *Filter) ([]*instance.Instance, error) {
 // Create creates a new service instance for service with id(sid/hash) and applies given env vars.
 func (i *Instance) Create(serviceHash hash.Hash, env []string) (*instance.Instance, error) {
 	// get the service from service db.
-	srv, err := i.serviceDB.Get(serviceHash)
+	srv, err := i.service.Get(serviceHash)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/instance/start.go
+++ b/sdk/instance/start.go
@@ -12,7 +12,7 @@ import (
 
 // Start starts the service.
 func (i *Instance) start(inst *instance.Instance, env []string) (serviceIDs []string, err error) {
-	srv, err := i.serviceDB.Get(inst.ServiceHash)
+	srv, err := i.service.Get(inst.ServiceHash)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/instance/stop.go
+++ b/sdk/instance/stop.go
@@ -10,7 +10,7 @@ import (
 
 // Stop stops an instance.
 func (i *Instance) stop(inst *instance.Instance) error {
-	srv, err := i.serviceDB.Get(inst.ServiceHash)
+	srv, err := i.service.Get(inst.ServiceHash)
 	if err != nil {
 		return err
 	}

--- a/sdk/instance/volume.go
+++ b/sdk/instance/volume.go
@@ -13,7 +13,7 @@ import (
 // service since extractVolumes() accepts service, not instance. same applies in the start
 // api as well. make it work with multiple instances.
 func (i *Instance) deleteData(inst *instance.Instance) error {
-	s, err := i.serviceDB.Get(inst.ServiceHash)
+	s, err := i.service.Get(inst.ServiceHash)
 	if err != nil {
 		return err
 	}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -23,7 +23,7 @@ func New(c container.Container, serviceDB database.ServiceDB, instanceDB databas
 	ps := pubsub.New(0)
 	serviceSDK := servicesdk.New(c, serviceDB)
 	instanceSDK := instancesdk.New(c, serviceSDK, instanceDB)
-	executionSDK := executionsdk.New(ps, serviceDB, execDB, instanceDB)
+	executionSDK := executionsdk.New(ps, serviceSDK, instanceSDK, execDB)
 	eventSDK := eventsdk.New(ps, serviceSDK)
 	return &SDK{
 		Service:   serviceSDK,

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -16,25 +16,19 @@ type SDK struct {
 	Instance  *instancesdk.Instance
 	Execution *executionsdk.Execution
 	Event     *eventsdk.Event
-
-	ps *pubsub.PubSub
-
-	container container.Container
-	db        database.ServiceDB
-	execDB    database.ExecutionDB
 }
 
 // New creates a new SDK with given options.
 func New(c container.Container, serviceDB database.ServiceDB, instanceDB database.InstanceDB, execDB database.ExecutionDB) *SDK {
 	ps := pubsub.New(0)
+	serviceSDK := servicesdk.New(c, serviceDB)
+	instanceSDK := instancesdk.New(c, serviceDB, instanceDB)
+	executionSDK := executionsdk.New(ps, serviceDB, execDB, instanceDB)
+	eventSDK := eventsdk.New(ps, serviceDB)
 	return &SDK{
-		Service:   servicesdk.New(c, db, execDB),
-		Instance:  instancesdk.New(c, db, instanceDB),
-		Execution: executionsdk.New(ps, db, execDB, instanceDB),
-		Event:     eventsdk.New(ps, db),
-		ps:        ps,
-		container: c,
-		db:        db,
-		execDB:    execDB,
+		Service:   serviceSDK,
+		Instance:  instanceSDK,
+		Execution: executionSDK,
+		Event:     eventSDK,
 	}
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -24,7 +24,7 @@ func New(c container.Container, serviceDB database.ServiceDB, instanceDB databas
 	serviceSDK := servicesdk.New(c, serviceDB)
 	instanceSDK := instancesdk.New(c, serviceDB, instanceDB)
 	executionSDK := executionsdk.New(ps, serviceDB, execDB, instanceDB)
-	eventSDK := eventsdk.New(ps, serviceDB)
+	eventSDK := eventsdk.New(ps, serviceSDK)
 	return &SDK{
 		Service:   serviceSDK,
 		Instance:  instanceSDK,

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -22,7 +22,7 @@ type SDK struct {
 func New(c container.Container, serviceDB database.ServiceDB, instanceDB database.InstanceDB, execDB database.ExecutionDB) *SDK {
 	ps := pubsub.New(0)
 	serviceSDK := servicesdk.New(c, serviceDB)
-	instanceSDK := instancesdk.New(c, serviceDB, instanceDB)
+	instanceSDK := instancesdk.New(c, serviceSDK, instanceDB)
 	executionSDK := executionsdk.New(ps, serviceDB, execDB, instanceDB)
 	eventSDK := eventsdk.New(ps, serviceSDK)
 	return &SDK{

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -25,7 +25,7 @@ type SDK struct {
 }
 
 // New creates a new SDK with given options.
-func New(c container.Container, db database.ServiceDB, instanceDB database.InstanceDB, execDB database.ExecutionDB) *SDK {
+func New(c container.Container, serviceDB database.ServiceDB, instanceDB database.InstanceDB, execDB database.ExecutionDB) *SDK {
 	ps := pubsub.New(0)
 	return &SDK{
 		Service:   servicesdk.New(c, db, execDB),

--- a/sdk/service/log.go
+++ b/sdk/service/log.go
@@ -1,4 +1,4 @@
-package sdk
+package servicesdk
 
 import (
 	"crypto/sha1"
@@ -18,24 +18,24 @@ type serviceLogFilters struct {
 	dependencies []string
 }
 
-// ServiceLogsFilter is a filter func for filtering service logs.
-type ServiceLogsFilter func(*serviceLogFilters)
+// LogsFilter is a filter func for filtering service logs.
+type LogsFilter func(*serviceLogFilters)
 
-// ServiceLogsDependenciesFilter returns a dependency filter.
-func ServiceLogsDependenciesFilter(dependencies ...string) ServiceLogsFilter {
+// LogsDependenciesFilter returns a dependency filter.
+func LogsDependenciesFilter(dependencies ...string) LogsFilter {
 	return func(s *serviceLogFilters) {
 		s.dependencies = dependencies
 	}
 }
 
-// ServiceLogs provides logs for dependencies of service serviceID that matches with filters.
+// Logs provides logs for dependencies of service serviceID that matches with filters.
 // when no dependency filters are set, all the dependencies' logs will be provided.
-func (sdk *SDK) ServiceLogs(serviceHash hash.Hash, filters ...ServiceLogsFilter) ([]*service.Log, error) {
+func (s *Service) Logs(serviceHash hash.Hash, filters ...LogsFilter) ([]*service.Log, error) {
 	f := &serviceLogFilters{}
 	for _, filter := range filters {
 		filter(f)
 	}
-	s, err := sdk.db.Get(serviceHash)
+	srv, err := s.serviceDB.Get(serviceHash)
 	if err != nil {
 		return nil, err
 	}
@@ -43,14 +43,14 @@ func (sdk *SDK) ServiceLogs(serviceHash hash.Hash, filters ...ServiceLogsFilter)
 		logs       []*service.Log
 		isNoFilter = len(f.dependencies) == 0
 	)
-	for _, d := range append(s.Dependencies, s.Configuration) {
+	for _, d := range append(srv.Dependencies, srv.Configuration) {
 		// Service.Configuration can be nil so, here is a check for it.
 		if d == nil {
 			continue
 		}
 		if isNoFilter || xstrings.SliceContains(f.dependencies, d.Key) {
 			var r io.ReadCloser
-			r, err := sdk.container.ServiceLogs(dependencyNamespace(serviceNamespace(s.Hash), d.Key))
+			r, err := s.container.ServiceLogs(dependencyNamespace(serviceNamespace(srv.Hash), d.Key))
 			if err != nil {
 				return nil, err
 			}

--- a/sdk/service/service.go
+++ b/sdk/service/service.go
@@ -95,5 +95,5 @@ func (s *Service) Get(hash hash.Hash) (*service.Service, error) {
 
 // List returns all services.
 func (s *Service) List() ([]*service.Service, error) {
-	return s.db.All()
+	return s.serviceDB.All()
 }

--- a/sdk/service/service.go
+++ b/sdk/service/service.go
@@ -21,8 +21,7 @@ type Service struct {
 	ps *pubsub.PubSub
 
 	container container.Container
-	db        database.ServiceDB
-	execDB    database.ExecutionDB
+	serviceDB database.ServiceDB
 }
 
 // New creates a new Service SDK with given options.
@@ -30,8 +29,7 @@ func New(c container.Container, db database.ServiceDB, execDB database.Execution
 	return &Service{
 		ps:        pubsub.New(0),
 		container: c,
-		db:        db,
-		execDB:    execDB,
+		serviceDB: db,
 	}
 }
 
@@ -66,7 +64,7 @@ func (s *Service) Create(srv *service.Service) (*service.Service, error) {
 	srv.Hash = hash.Hash(h)
 
 	// check if service is already deployed.
-	if _, err := s.db.Get(srv.Hash); err == nil {
+	if _, err := s.serviceDB.Get(srv.Hash); err == nil {
 		return nil, errors.New("service is already deployed")
 	}
 
@@ -82,15 +80,15 @@ func (s *Service) Create(srv *service.Service) (*service.Service, error) {
 		srv.Sid = "_" + srv.Hash.String()
 	}
 
-	return srv, s.db.Save(srv)
+	return srv, s.serviceDB.Save(srv)
 }
 
 // Delete deletes the service by hash.
 func (s *Service) Delete(hash hash.Hash) error {
-	return s.db.Delete(hash)
+	return s.serviceDB.Delete(hash)
 }
 
 // Get returns the service that matches given hash.
 func (s *Service) Get(hash hash.Hash) (*service.Service, error) {
-	return s.db.Get(hash)
+	return s.serviceDB.Get(hash)
 }

--- a/sdk/service/service.go
+++ b/sdk/service/service.go
@@ -25,11 +25,11 @@ type Service struct {
 }
 
 // New creates a new Service SDK with given options.
-func New(c container.Container, db database.ServiceDB, execDB database.ExecutionDB) *Service {
+func New(c container.Container, serviceDB database.ServiceDB) *Service {
 	return &Service{
 		ps:        pubsub.New(0),
 		container: c,
-		serviceDB: db,
+		serviceDB: serviceDB,
 	}
 }
 

--- a/server/grpc/core/logs.go
+++ b/server/grpc/core/logs.go
@@ -4,7 +4,7 @@ import (
 	"github.com/mesg-foundation/core/hash"
 	"github.com/mesg-foundation/core/protobuf/acknowledgement"
 	"github.com/mesg-foundation/core/protobuf/coreapi"
-	"github.com/mesg-foundation/core/sdk"
+	servicesdk "github.com/mesg-foundation/core/sdk/service"
 	"github.com/mesg-foundation/core/utils/chunker"
 )
 
@@ -15,8 +15,7 @@ func (s *Server) ServiceLogs(request *coreapi.ServiceLogsRequest, stream coreapi
 		return err
 	}
 
-	sl, err := s.sdk.ServiceLogs(hash,
-		sdk.ServiceLogsDependenciesFilter(request.Dependencies...))
+	sl, err := s.sdk.Service.Logs(hash, servicesdk.LogsDependenciesFilter(request.Dependencies...))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
dependency: https://github.com/mesg-foundation/engine/pull/1085

A SDK should only have access to its own database (eg: executionsdk have access to executiondb only). All the other data access should go through different sdks (servicesdk, instancesdk)