### PR TITLE
Fix error returned in service_validation

### DIFF
--- a/service/service_validate.go
+++ b/service/service_validate.go
@@ -81,7 +81,7 @@ func ValidateService(service *Service) error {
 			}
 		}
 	}
-	return errs
+	return errs.ErrorOrNil()
 }
 
 func newValidator() (*validator.Validate, ut.Translator) {


### PR DESCRIPTION
Fix error returned in `service_validation`. It was always returning `errs xerrors.Errors` that is an array so it was never nil.