### PR TITLE
fix confusion with service and instance hash

### DIFF
--- a/sdk/execution/execution.go
+++ b/sdk/execution/execution.go
@@ -111,7 +111,12 @@ func (e *Execution) validateExecutionOutput(instanceHash hash.Hash, taskKey stri
 		return nil, fmt.Errorf("invalid output: %s", err)
 	}
 
-	s, err := e.service.Get(instanceHash)
+	i, err := e.instance.Get(instanceHash)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := e.service.Get(i.ServiceHash)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +146,7 @@ func (e *Execution) Execute(instanceHash hash.Hash, taskKey string, inputData ma
 
 	// execute the task.
 	eventID := uuid.NewV4().String()
-	exec := execution.New(s.Hash, nil, eventID, taskKey, inputData, tags)
+	exec := execution.New(instance.Hash, nil, eventID, taskKey, inputData, tags)
 	if err := exec.Execute(); err != nil {
 		return nil, err
 	}
@@ -150,7 +155,7 @@ func (e *Execution) Execute(instanceHash hash.Hash, taskKey string, inputData ma
 	}
 
 	go e.ps.Pub(exec, streamTopic)
-	go e.ps.Pub(exec, subTopic(s.Hash))
+	go e.ps.Pub(exec, subTopic(instance.Hash))
 	return exec.Hash, nil
 }
 


### PR DESCRIPTION
- [x] stream based on instance
- [x]  right hash in the execution fix https://github.com/mesg-foundation/engine/issues/1136

This can be tested with this service (that includes the new version of mesg-js)
```json
{"sid":"testservice","name":"test service","tasks":[{"key":"taskx","inputs":[{"key":"foo","type":"String","object":[]},{"key":"bar","type":"String","object":[]}],"outputs":[{"key":"result","type":"String","object":[]}]}],"events":[{"key":"event","data":[{"key":"x","type":"Any","object":[]}]}],"dependencies":[{"key":"nginx","image":"nginx","volumes":["/etc/nginx"]}],"configuration":{"volumes":["/volume/test/"],"volumesFrom":["nginx"],"env":["ENVA=do_not_override","ENVB=override"]},"source":"QmWfes1BjPVcaXS6naBGrcJw4wvm2Fa85hTXBAgKuLmjGx"}
```