### PR TITLE
fix issue with instance hash not saved

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,8 @@ type Config struct {
 		InstanceRelativePath  string
 		ExecutionRelativePath string
 	}
+
+	SystemServices []*ServiceConfig
 }
 
 // New creates a new config with default values.
@@ -64,6 +66,7 @@ func New() (*Config, error) {
 	c.Database.ServiceRelativePath = filepath.Join("database", "services", serviceDBVersion)
 	c.Database.InstanceRelativePath = filepath.Join("database", "instance", instanceDBVersion)
 	c.Database.ExecutionRelativePath = filepath.Join("database", "executions", executionDBVersion)
+	c.setupServices()
 	return &c, nil
 }
 

--- a/config/services.go
+++ b/config/services.go
@@ -34,8 +34,8 @@ type ServiceConfig struct {
 	Instance   *instance.Instance
 }
 
-// Services return the config for all services.
-func (c *Config) Services() ([]ServiceConfig, error) {
+// setupServices initialize all services for this config
+func (c *Config) setupServices() ([]ServiceConfig, error) {
 	serviceConfigs := make([]ServiceConfig, 0)
 	if marketplaceCompiled != "" {
 		marketplace, err := c.createServiceConfig("Marketplace", marketplaceCompiled, map[string]string{
@@ -46,18 +46,18 @@ func (c *Config) Services() ([]ServiceConfig, error) {
 		if err != nil {
 			return nil, err
 		}
-		serviceConfigs = append(serviceConfigs, marketplace)
+		c.SystemServices = append(c.SystemServices, marketplace)
 	}
 	return serviceConfigs, nil
 }
 
-func (c *Config) createServiceConfig(key string, compilatedJSON string, env map[string]string) (ServiceConfig, error) {
+func (c *Config) createServiceConfig(key string, compilatedJSON string, env map[string]string) (*ServiceConfig, error) {
 	var srv service.Service
 	if err := json.Unmarshal([]byte(compilatedJSON), &srv); err != nil {
-		return ServiceConfig{}, err
+		return nil, err
 	}
 	srv.Configuration.Key = service.MainServiceKey
-	return ServiceConfig{
+	return &ServiceConfig{
 		Key:        key,
 		Definition: &srv,
 		Env:        env,

--- a/core/main.go
+++ b/core/main.go
@@ -72,11 +72,7 @@ func initDependencies() (*dependencies, error) {
 }
 
 func deployCoreServices(config *config.Config, sdk *sdk.SDK) error {
-	services, err := config.Services()
-	if err != nil {
-		return err
-	}
-	for _, serviceConfig := range services {
+	for _, serviceConfig := range config.SystemServices {
 		logrus.Infof("Deploying service %q", serviceConfig.Definition.Sid)
 		srv, err := sdk.Service.Create(serviceConfig.Definition)
 		if err != nil {

--- a/server/grpc/core/core.go
+++ b/server/grpc/core/core.go
@@ -25,10 +25,7 @@ func (s *Server) Info(ctx context.Context, request *coreapi.InfoRequest) (*corea
 	if err != nil {
 		return nil, err
 	}
-	servicesFromConfig, err := c.Services()
-	if err != nil {
-		return nil, err
-	}
+	servicesFromConfig := c.SystemServices
 	services := make([]*coreapi.InfoReply_CoreService, len(servicesFromConfig))
 	for i, s := range servicesFromConfig {
 		services[i] = &coreapi.InfoReply_CoreService{

--- a/server/grpc/core/core_integration_test.go
+++ b/server/grpc/core/core_integration_test.go
@@ -20,9 +20,7 @@ func TestInfo(t *testing.T) {
 	reply, err := server.Info(context.Background(), &coreapi.InfoRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, reply)
-	services, err := c.Services()
-	require.NoError(t, err)
 	for i, s := range reply.Services {
-		require.Equal(t, s.Sid, services[i].Definition.Sid)
+		require.Equal(t, s.Sid, c.SystemServices[i].Definition.Sid)
 	}
 }


### PR DESCRIPTION
system services were started correctly but the state of these system services was not kept in memory and the Info api could not return the instance hash

to test:
```
grpcurl -plaintext :50052 api.Core/Info
```
and verify that hash is present