### PR TITLE
Fix bad variable name in build-engine

### DIFF
--- a/dev
+++ b/dev
@@ -28,8 +28,7 @@ for s in systemservices/* ; do
   if [ -d "$s" ]; then
     pushd $s > /dev/null
     name=$(basename "$s")
-    varname="${name}"
-    LDFLAGS+=" -X 'github.com/mesg-foundation/engine/config.${varname}Compiled=$(cat compiled.json)'"
+    LDFLAGS+=" -X 'github.com/mesg-foundation/engine/config.${name}Compiled=$(cat compiled.json)'"
     popd > /dev/null
   fi
 done

--- a/scripts/build-engine.sh
+++ b/scripts/build-engine.sh
@@ -9,8 +9,7 @@ for s in systemservices/* ; do
   if [ -d "$s" ]; then
     pushd $s > /dev/null
     name=$(basename "$s")
-    varname="${name^}"
-    LDFLAGS+=" -X 'github.com/mesg-foundation/engine/config.${varname}Compiled=$(cat compiled.json)'"
+    LDFLAGS+=" -X 'github.com/mesg-foundation/engine/config.${name}Compiled=$(cat compiled.json)'"
     popd > /dev/null
   fi
 done


### PR DESCRIPTION
The config variable name is lowercase. not need to uppercased it.