### PR TITLE
Attach event to execution

### DIFF
--- a/sdk/execution/execution_test.go
+++ b/sdk/execution/execution_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cskr/pubsub"
 	"github.com/mesg-foundation/engine/container/mocks"
 	"github.com/mesg-foundation/engine/database"
+	"github.com/mesg-foundation/engine/event"
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/instance"
@@ -113,11 +114,11 @@ func TestExecute(t *testing.T) {
 	require.NoError(t, at.serviceDB.Save(testService))
 	require.NoError(t, at.instanceDB.Save(testInstance))
 
-	_, err := sdk.Execute(testInstance.Hash, testService.Tasks[0].Key, nil, nil)
+	_, err := sdk.Execute(testInstance.Hash, &event.Event{}, testService.Tasks[0].Key, nil)
 	require.NoError(t, err)
 
 	// not existing instance
-	_, err = sdk.Execute(hash.Int(3), testService.Tasks[0].Key, nil, nil)
+	_, err = sdk.Execute(hash.Int(3), &event.Event{}, testService.Tasks[0].Key, nil)
 	require.Error(t, err)
 }
 
@@ -127,7 +128,7 @@ func TestExecuteInvalidTaskKey(t *testing.T) {
 
 	require.NoError(t, at.serviceDB.Save(testService))
 
-	_, err := sdk.Execute(testService.Hash, "-", nil, nil)
+	_, err := sdk.Execute(testService.Hash, &event.Event{}, "-", nil)
 	require.Error(t, err)
 }
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -46,7 +46,7 @@ func (w *Workflow) processEvent(event *event.Event) {
 		w.ErrC <- err
 	}
 	for _, workflow := range workflows {
-		_, err := w.execution.Execute(workflow.Task.InstanceHash, workflow.Task.TaskKey, event.Data, []string{})
+		_, err := w.execution.Execute(workflow.Task.InstanceHash, event, workflow.Task.TaskKey, []string{})
 		if err != nil {
 			w.ErrC <- err
 			continue


### PR DESCRIPTION
- Allow SDK to accept event (and not create the even internally)
- Attach the event to executions from the workflow engine

Before merging, we need to have the best solution for the `Execution/Create` API. Every execution should be triggered by an event so the API is creating an event but there are 2 ways to do that, please check the comment below and let me know what you think.

https://github.com/mesg-foundation/engine/blob/082f506a618b56c4e2129d334b87a945833121b1/server/grpc/api/execution.go#L44-L59