### PR TITLE
End of execution event

### DIFF
--- a/event/engine.go
+++ b/event/engine.go
@@ -1,0 +1,28 @@
+package event
+
+import (
+	"github.com/mesg-foundation/engine/hash"
+)
+
+// a 44 length constant hash
+const engineEventHash = "EngineEventEngineEventEngineEventEngineEvent"
+
+// EngineEventType type to describe engine events
+// Engine events doesn't need the same validation that normal events need
+// These events are used internally only and cannot be emitted by services
+type EngineEventType string
+
+const (
+	// EngineAPIExecution This event is triggered when the `execution/create` API is called
+	EngineAPIExecution EngineEventType = "engine-api-execution"
+)
+
+// EngineEvent creates an engine event
+func EngineEvent(evtType EngineEventType, data map[string]interface{}) *Event {
+	instanceHash, err := hash.Decode(engineEventHash)
+	if err != nil {
+		// This panics because this is a developer mistake
+		panic("engineEventHash should be codable")
+	}
+	return Create(instanceHash, string(evtType), data)
+}

--- a/event/engine.go
+++ b/event/engine.go
@@ -7,11 +7,11 @@ type EngineEventType string
 
 const (
 	// EngineAPIExecution This event is triggered when the `execution/create` API is called
-	EngineAPIExecution EngineEventType = "engine-api-execution"
+	EngineAPIExecution EngineEventType = "mesg:engine-api-execution"
 )
 
 // EngineEvent creates an engine event.
 // Engine event does not have any instance hash and are prefixed by mesg:
 func EngineEvent(evtType EngineEventType, data map[string]interface{}) *Event {
-	return Create(nil, "mesg:"+string(evtType), data)
+	return Create(nil, string(evtType), data)
 }

--- a/event/engine.go
+++ b/event/engine.go
@@ -8,6 +8,8 @@ type EngineEventType string
 const (
 	// EngineAPIExecution This event is triggered when the `execution/create` API is called
 	EngineAPIExecution EngineEventType = "mesg:engine-api-execution"
+	// EndOfExecution This event is triggered when an execution is completed
+	EndOfExecution EngineEventType = "mesg:engine-end-of-execution"
 )
 
 // EngineEvent creates an engine event.

--- a/event/engine.go
+++ b/event/engine.go
@@ -1,12 +1,5 @@
 package event
 
-import (
-	"github.com/mesg-foundation/engine/hash"
-)
-
-// a 44 length constant hash
-const engineEventHash = "EngineEventEngineEventEngineEventEngineEvent"
-
 // EngineEventType type to describe engine events
 // Engine events doesn't need the same validation that normal events need
 // These events are used internally only and cannot be emitted by services
@@ -17,12 +10,8 @@ const (
 	EngineAPIExecution EngineEventType = "engine-api-execution"
 )
 
-// EngineEvent creates an engine event
+// EngineEvent creates an engine event.
+// Engine event does not have any instance hash and are prefixed by mesg:
 func EngineEvent(evtType EngineEventType, data map[string]interface{}) *Event {
-	instanceHash, err := hash.Decode(engineEventHash)
-	if err != nil {
-		// This panics because this is a developer mistake
-		panic("engineEventHash should be codable")
-	}
-	return Create(instanceHash, string(evtType), data)
+	return Create(nil, "mesg:"+string(evtType), data)
 }

--- a/event/engine_test.go
+++ b/event/engine_test.go
@@ -11,7 +11,7 @@ func TestDigest(t *testing.T) {
 		"foo": "bar",
 	})
 	assert.Equal(t, e.InstanceHash.String(), "")
-	assert.Equal(t, e.Key, "mesg:"+string(EngineAPIExecution))
+	assert.Equal(t, e.Key, string(EngineAPIExecution))
 	assert.Equal(t, e.Data["foo"], "bar")
 	assert.Equal(t, e.Hash.String(), "6UW521vQ9KbdDpCYbcKu2FGPLfK8Gsy9kfyF77pzYbYC")
 }

--- a/event/engine_test.go
+++ b/event/engine_test.go
@@ -10,8 +10,8 @@ func TestDigest(t *testing.T) {
 	e := EngineEvent(EngineAPIExecution, map[string]interface{}{
 		"foo": "bar",
 	})
-	assert.Equal(t, e.InstanceHash.String(), engineEventHash)
-	assert.Equal(t, e.Key, string(EngineAPIExecution))
+	assert.Equal(t, e.InstanceHash.String(), "")
+	assert.Equal(t, e.Key, "mesg:"+string(EngineAPIExecution))
 	assert.Equal(t, e.Data["foo"], "bar")
-	assert.Equal(t, e.Hash.String(), "5oHsDq9Njo4uRmjo6ehD3FREYuH6o6PbELn6vYahHAay")
+	assert.Equal(t, e.Hash.String(), "6UW521vQ9KbdDpCYbcKu2FGPLfK8Gsy9kfyF77pzYbYC")
 }

--- a/event/engine_test.go
+++ b/event/engine_test.go
@@ -1,0 +1,17 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDigest(t *testing.T) {
+	e := EngineEvent(EngineAPIExecution, map[string]interface{}{
+		"foo": "bar",
+	})
+	assert.Equal(t, e.InstanceHash.String(), engineEventHash)
+	assert.Equal(t, e.Key, string(EngineAPIExecution))
+	assert.Equal(t, e.Data["foo"], "bar")
+	assert.Equal(t, e.Hash.String(), "5oHsDq9Njo4uRmjo6ehD3FREYuH6o6PbELn6vYahHAay")
+}

--- a/sdk/event/event.go
+++ b/sdk/event/event.go
@@ -51,6 +51,13 @@ func (e *Event) Create(instanceHash hash.Hash, eventKey string, eventData map[st
 	return event, nil
 }
 
+// CreateEngineEvent creates and publishes an engine event
+func (e *Event) CreateEngineEvent(eventType event.EngineEventType, data map[string]interface{}) *event.Event {
+	evt := event.EngineEvent(eventType, data)
+	go e.ps.Pub(evt, streamTopic)
+	return evt
+}
+
 // GetStream broadcasts all events.
 func (e *Event) GetStream(f *Filter) *Listener {
 	l := NewListener(e.ps, streamTopic, f)

--- a/sdk/execution/execution_test.go
+++ b/sdk/execution/execution_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/instance"
+	eventsdk "github.com/mesg-foundation/engine/sdk/event"
 	instancesdk "github.com/mesg-foundation/engine/sdk/instance"
 	servicesdk "github.com/mesg-foundation/engine/sdk/service"
 	"github.com/mesg-foundation/engine/service"
@@ -40,10 +41,12 @@ func (t *apiTesting) close() {
 }
 
 func newTesting(t *testing.T) (*Execution, *apiTesting) {
+	ps := pubsub.New(0)
 	container := &mocks.Container{}
 	db, err := database.NewServiceDB(servicedbname)
 	require.NoError(t, err)
 	service := servicesdk.New(container, db)
+	event := eventsdk.New(ps, nil, nil)
 
 	instDB, err := database.NewInstanceDB(instdbname)
 	require.NoError(t, err)
@@ -52,7 +55,7 @@ func newTesting(t *testing.T) (*Execution, *apiTesting) {
 	execDB, err := database.NewExecutionDB(execdbname)
 	require.NoError(t, err)
 
-	sdk := New(pubsub.New(0), service, instance, execDB)
+	sdk := New(ps, service, instance, event, execDB)
 
 	return sdk, &apiTesting{
 		T:           t,

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -23,8 +23,8 @@ func New(c container.Container, serviceDB database.ServiceDB, instanceDB databas
 	ps := pubsub.New(0)
 	serviceSDK := servicesdk.New(c, serviceDB)
 	instanceSDK := instancesdk.New(c, serviceSDK, instanceDB, engineName, port)
-	executionSDK := executionsdk.New(ps, serviceSDK, instanceSDK, execDB)
 	eventSDK := eventsdk.New(ps, serviceSDK, instanceSDK)
+	executionSDK := executionsdk.New(ps, serviceSDK, instanceSDK, eventSDK, execDB)
 	return &SDK{
 		Service:   serviceSDK,
 		Instance:  instanceSDK,

--- a/server/grpc/api/execution.go
+++ b/server/grpc/api/execution.go
@@ -41,7 +41,7 @@ func (s *ExecutionServer) Create(ctx context.Context, req *api.CreateExecutionRe
 		return nil, fmt.Errorf("cannot parse execution's inputs (JSON format): %s", err)
 	}
 
-	evt := event.EngineEvent(event.EngineAPIExecution, inputs)
+	evt := s.sdk.Event.CreateEngineEvent(event.EngineAPIExecution, inputs)
 
 	executionHash, err := s.sdk.Execution.Execute(instanceHash, evt, req.TaskKey, req.Tags)
 	if err != nil {

--- a/server/grpc/api/execution.go
+++ b/server/grpc/api/execution.go
@@ -41,22 +41,7 @@ func (s *ExecutionServer) Create(ctx context.Context, req *api.CreateExecutionRe
 		return nil, fmt.Errorf("cannot parse execution's inputs (JSON format): %s", err)
 	}
 
-	eventHash, err := hash.Random()
-	if err != nil {
-		return nil, err
-	}
-	evt := &event.Event{
-		Hash:         eventHash,
-		InstanceHash: instanceHash,
-		Data:         inputs,
-	}
-	// Or the following but it needs to create a hack to skip the validation
-	// because the event is not present in the service. We could have an additional
-	// parameter `skipValidation` but I'm not a huge fan
-	// evt, err := s.sdk.Event.Create(hash, "api-call", inputs)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	evt := event.EngineEvent(event.EngineAPIExecution, inputs)
 
 	executionHash, err := s.sdk.Execution.Execute(instanceHash, evt, req.TaskKey, req.Tags)
 	if err != nil {

--- a/server/grpc/api/execution_test.go
+++ b/server/grpc/api/execution_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/sdk"
+	"github.com/mesg-foundation/engine/hash"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +33,28 @@ func TestGet(t *testing.T) {
 	got, err := s.Get(context.Background(), &api.GetExecutionRequest{Hash: exec.Hash.String()})
 	require.NoError(t, err)
 	require.Equal(t, got, want)
+}
+
+func TestCreateWithInvalidHash(t *testing.T) {
+	sdk := sdk.New(nil, nil, nil, nil, "", "")
+	s := NewExecutionServer(sdk)
+
+	_, err := s.Create(context.Background(), &api.CreateExecutionRequest{
+		InstanceHash: "xx",
+	})
+	require.Error(t, err)
+}
+
+func TestCreateWithInvalidInputs(t *testing.T) {
+	sdk := sdk.New(nil, nil, nil, nil, "", "")
+	s := NewExecutionServer(sdk)
+
+	h, _ := hash.Random()
+	_, err := s.Create(context.Background(), &api.CreateExecutionRequest{
+		InstanceHash: h.String(),
+		Inputs: "xx",
+	})
+	require.Error(t, err)
 }
 
 func TestUpdate(t *testing.T) {

--- a/server/grpc/api/execution_test.go
+++ b/server/grpc/api/execution_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/mesg-foundation/engine/database"
 	"github.com/mesg-foundation/engine/execution"
+	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/sdk"
-	"github.com/mesg-foundation/engine/hash"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,7 +52,7 @@ func TestCreateWithInvalidInputs(t *testing.T) {
 	h, _ := hash.Random()
 	_, err := s.Create(context.Background(), &api.CreateExecutionRequest{
 		InstanceHash: h.String(),
-		Inputs: "xx",
+		Inputs:       "xx",
 	})
 	require.Error(t, err)
 }


### PR DESCRIPTION
dependency: https://github.com/mesg-foundation/engine/pull/1178

Creates an event at the end of execution with all the details of this execution. This will be useful for the workflow system that can now connect normal events and events from any end of execution.

These events are published on the event stream and can be filtered too like any other events.