### PR TITLE
Workflow filters

### DIFF
--- a/workflow/type.go
+++ b/workflow/type.go
@@ -1,9 +1,19 @@
 package workflow
 
-import "github.com/mesg-foundation/engine/hash"
+import (
+	"github.com/mesg-foundation/engine/event"
+	"github.com/mesg-foundation/engine/hash"
+)
 
 // These structs are temporary and will be part of the service definition
 // TODO: Move to service struct
+
+type predicate uint
+
+// Possible status for services.
+const (
+	EQ predicate = iota
+)
 
 type workflow struct {
 	Trigger trigger
@@ -15,8 +25,43 @@ type task struct {
 	TaskKey      string
 }
 
+type filter struct {
+	Key       string
+	Predicate predicate
+	Value     interface{}
+}
+
 // Trigger is an event that triggers a workflow
 type trigger struct {
 	InstanceHash hash.Hash
 	EventKey     string
+	Filters      []*filter
+}
+
+func (t *trigger) Match(evt *event.Event) (bool, error) {
+	instanceHash := evt.InstanceHash
+	if !t.InstanceHash.Equal(instanceHash) {
+		return false, nil
+	}
+
+	if t.EventKey != evt.Key {
+		return false, nil
+	}
+
+	for _, filter := range t.Filters {
+		if !filter.Match(evt.Data) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (f *filter) Match(inputs map[string]interface{}) bool {
+	switch f.Predicate {
+	case EQ:
+		return inputs[f.Key] == f.Value
+	default:
+		return false
+	}
 }

--- a/workflow/type.go
+++ b/workflow/type.go
@@ -38,23 +38,22 @@ type trigger struct {
 	Filters      []*filter
 }
 
-func (t *trigger) Match(evt *event.Event) (bool, error) {
-	instanceHash := evt.InstanceHash
-	if !t.InstanceHash.Equal(instanceHash) {
-		return false, nil
+func (t *trigger) Match(evt *event.Event) bool {
+	if !t.InstanceHash.Equal(evt.InstanceHash) {
+		return false
 	}
 
 	if t.EventKey != evt.Key {
-		return false, nil
+		return false
 	}
 
 	for _, filter := range t.Filters {
 		if !filter.Match(evt.Data) {
-			return false, nil
+			return false
 		}
 	}
 
-	return true, nil
+	return true
 }
 
 func (f *filter) Match(inputs map[string]interface{}) bool {

--- a/workflow/type_test.go
+++ b/workflow/type_test.go
@@ -1,0 +1,76 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/mesg-foundation/engine/event"
+	"github.com/mesg-foundation/engine/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatch(t *testing.T) {
+	var tests = []struct {
+		trigger *trigger
+		event   *event.Event
+		match   bool
+	}{
+		{ // matching event
+			&trigger{InstanceHash: hash.Int(1), EventKey: "xx"},
+			&event.Event{InstanceHash: hash.Int(1), Key: "xx"},
+			true,
+		},
+		{ // not matching instance
+			&trigger{InstanceHash: hash.Int(1)},
+			&event.Event{InstanceHash: hash.Int(2)},
+			false,
+		},
+		{ // not matching event
+			&trigger{InstanceHash: hash.Int(1), EventKey: "xx"},
+			&event.Event{InstanceHash: hash.Int(1), Key: "yy"},
+			false,
+		},
+		{ // matching filter
+			&trigger{InstanceHash: hash.Int(1), EventKey: "xx", Filters: []*filter{
+				{Key: "foo", Predicate: EQ, Value: "bar"},
+			}},
+			&event.Event{InstanceHash: hash.Int(1), Key: "xx", Data: map[string]interface{}{"foo": "bar"}},
+			true,
+		},
+		{ // not matching filter
+			&trigger{InstanceHash: hash.Int(1), EventKey: "xx", Filters: []*filter{
+				{Key: "foo", Predicate: EQ, Value: "xx"},
+			}},
+			&event.Event{InstanceHash: hash.Int(1), Key: "xx", Data: map[string]interface{}{"foo": "bar"}},
+			false,
+		},
+		{ // matching multiple filters
+			&trigger{InstanceHash: hash.Int(1), EventKey: "xx", Filters: []*filter{
+				{Key: "foo", Predicate: EQ, Value: "bar"},
+				{Key: "xxx", Predicate: EQ, Value: "yyy"},
+			}},
+			&event.Event{InstanceHash: hash.Int(1), Key: "xx", Data: map[string]interface{}{
+				"foo": "bar",
+				"xxx": "yyy",
+				"aaa": "bbb",
+			}},
+			true,
+		},
+		{ // non matching multiple filters
+			&trigger{InstanceHash: hash.Int(1), EventKey: "xx", Filters: []*filter{
+				{Key: "foo", Predicate: EQ, Value: "bar"},
+				{Key: "xxx", Predicate: EQ, Value: "aaa"},
+			}},
+			&event.Event{InstanceHash: hash.Int(1), Key: "xx", Data: map[string]interface{}{
+				"foo": "bar",
+				"xxx": "yyy",
+				"aaa": "bbb",
+			}},
+			false,
+		},
+	}
+	for i, test := range tests {
+		match, err := test.trigger.Match(test.event)
+		assert.NoError(t, err)
+		assert.Equal(t, test.match, match, i)
+	}
+}

--- a/workflow/type_test.go
+++ b/workflow/type_test.go
@@ -69,8 +69,7 @@ func TestMatch(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		match, err := test.trigger.Match(test.event)
-		assert.NoError(t, err)
+		match := test.trigger.Match(test.event)
 		assert.Equal(t, test.match, match, i)
 	}
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -34,11 +34,6 @@ func (w *Workflow) Start() error {
 	if w.eventStream != nil {
 		return fmt.Errorf("workflow engine already running")
 	}
-	go func() {
-		for err := range w.ErrC {
-			logrus.Error(err)
-		}
-	}()
 	w.eventStream = w.event.GetStream(nil)
 	for event := range w.eventStream.C {
 		go w.processEvent(event)

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mesg-foundation/engine/hash"
 	eventsdk "github.com/mesg-foundation/engine/sdk/event"
 	executionsdk "github.com/mesg-foundation/engine/sdk/execution"
-	"github.com/sirupsen/logrus"
 )
 
 // Workflow exposes functions of the workflow
@@ -62,11 +61,7 @@ func (w *Workflow) findMatchingWorkflows(event *event.Event) ([]*workflow, error
 	}
 	workflows := make([]*workflow, 0)
 	for _, wf := range all {
-		match, err := wf.Trigger.Match(event)
-		if err != nil {
-			return nil, err
-		}
-		if match {
+		if wf.Trigger.Match(event) {
 			workflows = append(workflows, wf)
 		}
 	}


### PR DESCRIPTION
Add possibility to filter event data on the workflow.
Workflow can have a list of filters. All filters of a workflow should match to trigger a task.

Filters have 3 attributes:
- Key: the key we want to filter
- Predicate: the predicate we want to use (for now only EQ (equal) is implemented)
- Value: the expected value

**Test:**
Follow the steps in https://github.com/mesg-foundation/engine/pull/1172 but make sure to listen the stream before starting the service.
The service will emit events that auto increment and when the event has the output `world-2` the execution will be created and only at this moment.
The counter is saved in a volume so make sure to stop the instance with the `delete-data` attribute