### PR TITLE
Add support of results for workflow triggers

### DIFF
--- a/sdk/execution/execution_test.go
+++ b/sdk/execution/execution_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cskr/pubsub"
 	"github.com/mesg-foundation/engine/container/mocks"
 	"github.com/mesg-foundation/engine/database"
-	"github.com/mesg-foundation/engine/event"
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/instance"
@@ -114,11 +113,11 @@ func TestExecute(t *testing.T) {
 	require.NoError(t, at.serviceDB.Save(testService))
 	require.NoError(t, at.instanceDB.Save(testInstance))
 
-	_, err := sdk.Execute(testInstance.Hash, &event.Event{}, testService.Tasks[0].Key, nil)
+	_, err := sdk.Execute(testInstance.Hash, hash.Int(1), nil, testService.Tasks[0].Key, map[string]interface{}{}, nil)
 	require.NoError(t, err)
 
 	// not existing instance
-	_, err = sdk.Execute(hash.Int(3), &event.Event{}, testService.Tasks[0].Key, nil)
+	_, err = sdk.Execute(hash.Int(3), hash.Int(1), nil, testService.Tasks[0].Key, map[string]interface{}{}, nil)
 	require.Error(t, err)
 }
 
@@ -128,7 +127,7 @@ func TestExecuteInvalidTaskKey(t *testing.T) {
 
 	require.NoError(t, at.serviceDB.Save(testService))
 
-	_, err := sdk.Execute(testService.Hash, &event.Event{}, "-", nil)
+	_, err := sdk.Execute(testService.Hash, hash.Int(1), nil, "-", map[string]interface{}{}, nil)
 	require.Error(t, err)
 }
 

--- a/server/grpc/api/execution.go
+++ b/server/grpc/api/execution.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/mesg-foundation/engine/event"
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/protobuf/acknowledgement"
@@ -45,20 +44,7 @@ func (s *ExecutionServer) Create(ctx context.Context, req *api.CreateExecutionRe
 	if err != nil {
 		return nil, err
 	}
-	evt := &event.Event{
-		Hash:         eventHash,
-		InstanceHash: instanceHash,
-		Data:         inputs,
-	}
-	// Or the following but it needs to create a hack to skip the validation
-	// because the event is not present in the service. We could have an additional
-	// parameter `skipValidation` but I'm not a huge fan
-	// evt, err := s.sdk.Event.Create(hash, "api-call", inputs)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	executionHash, err := s.sdk.Execution.Execute(instanceHash, evt, req.TaskKey, req.Tags)
+	executionHash, err := s.sdk.Execution.Execute(instanceHash, eventHash, nil, req.TaskKey, inputs, req.Tags)
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/type.go
+++ b/workflow/type.go
@@ -1,7 +1,6 @@
 package workflow
 
 import (
-	"github.com/mesg-foundation/engine/event"
 	"github.com/mesg-foundation/engine/hash"
 )
 
@@ -14,6 +13,7 @@ type predicate uint
 const (
 	EQ predicate = iota
 )
+
 type triggerType uint
 
 const (
@@ -47,17 +47,20 @@ type trigger struct {
 	Filters      []*filter
 }
 
-func (t *trigger) MatchEvent(evt *event.Event) bool {
-	if !t.InstanceHash.Equal(evt.InstanceHash) {
+func (t *trigger) Match(trigger triggerType, instanceHash hash.Hash, key string, data map[string]interface{}) bool {
+	if t.Type != trigger {
+		return false
+	}
+	if !t.InstanceHash.Equal(instanceHash) {
 		return false
 	}
 
-	if t.Key != evt.Key {
+	if t.Key != key {
 		return false
 	}
 
 	for _, filter := range t.Filters {
-		if !filter.Match(evt.Data) {
+		if !filter.Match(data) {
 			return false
 		}
 	}

--- a/workflow/type.go
+++ b/workflow/type.go
@@ -14,6 +14,14 @@ type predicate uint
 const (
 	EQ predicate = iota
 )
+type triggerType uint
+
+const (
+	// Event is an event emitted by a service
+	Event triggerType = iota
+	// Result is the result of a task execution
+	Result
+)
 
 type workflow struct {
 	Trigger trigger
@@ -34,16 +42,17 @@ type filter struct {
 // Trigger is an event that triggers a workflow
 type trigger struct {
 	InstanceHash hash.Hash
-	EventKey     string
+	Key          string
+	Type         triggerType
 	Filters      []*filter
 }
 
-func (t *trigger) Match(evt *event.Event) bool {
+func (t *trigger) MatchEvent(evt *event.Event) bool {
 	if !t.InstanceHash.Equal(evt.InstanceHash) {
 		return false
 	}
 
-	if t.EventKey != evt.Key {
+	if t.Key != evt.Key {
 		return false
 	}
 

--- a/workflow/type_test.go
+++ b/workflow/type_test.go
@@ -69,7 +69,7 @@ func TestMatch(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		match := test.trigger.MatchEvent(test.event)
+		match := test.trigger.Match(Event, test.event.InstanceHash, test.event.Key, test.event.Data)
 		assert.Equal(t, test.match, match, i)
 	}
 }

--- a/workflow/type_test.go
+++ b/workflow/type_test.go
@@ -15,7 +15,7 @@ func TestMatch(t *testing.T) {
 		match   bool
 	}{
 		{ // matching event
-			&trigger{InstanceHash: hash.Int(1), EventKey: "xx"},
+			&trigger{InstanceHash: hash.Int(1), Key: "xx"},
 			&event.Event{InstanceHash: hash.Int(1), Key: "xx"},
 			true,
 		},
@@ -25,26 +25,26 @@ func TestMatch(t *testing.T) {
 			false,
 		},
 		{ // not matching event
-			&trigger{InstanceHash: hash.Int(1), EventKey: "xx"},
+			&trigger{InstanceHash: hash.Int(1), Key: "xx"},
 			&event.Event{InstanceHash: hash.Int(1), Key: "yy"},
 			false,
 		},
 		{ // matching filter
-			&trigger{InstanceHash: hash.Int(1), EventKey: "xx", Filters: []*filter{
+			&trigger{InstanceHash: hash.Int(1), Key: "xx", Filters: []*filter{
 				{Key: "foo", Predicate: EQ, Value: "bar"},
 			}},
 			&event.Event{InstanceHash: hash.Int(1), Key: "xx", Data: map[string]interface{}{"foo": "bar"}},
 			true,
 		},
 		{ // not matching filter
-			&trigger{InstanceHash: hash.Int(1), EventKey: "xx", Filters: []*filter{
+			&trigger{InstanceHash: hash.Int(1), Key: "xx", Filters: []*filter{
 				{Key: "foo", Predicate: EQ, Value: "xx"},
 			}},
 			&event.Event{InstanceHash: hash.Int(1), Key: "xx", Data: map[string]interface{}{"foo": "bar"}},
 			false,
 		},
 		{ // matching multiple filters
-			&trigger{InstanceHash: hash.Int(1), EventKey: "xx", Filters: []*filter{
+			&trigger{InstanceHash: hash.Int(1), Key: "xx", Filters: []*filter{
 				{Key: "foo", Predicate: EQ, Value: "bar"},
 				{Key: "xxx", Predicate: EQ, Value: "yyy"},
 			}},
@@ -56,7 +56,7 @@ func TestMatch(t *testing.T) {
 			true,
 		},
 		{ // non matching multiple filters
-			&trigger{InstanceHash: hash.Int(1), EventKey: "xx", Filters: []*filter{
+			&trigger{InstanceHash: hash.Int(1), Key: "xx", Filters: []*filter{
 				{Key: "foo", Predicate: EQ, Value: "bar"},
 				{Key: "xxx", Predicate: EQ, Value: "aaa"},
 			}},
@@ -69,7 +69,7 @@ func TestMatch(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		match := test.trigger.Match(test.event)
+		match := test.trigger.MatchEvent(test.event)
 		assert.Equal(t, test.match, match, i)
 	}
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/mesg-foundation/engine/event"
+	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	eventsdk "github.com/mesg-foundation/engine/sdk/event"
 	executionsdk "github.com/mesg-foundation/engine/sdk/execution"
@@ -14,7 +15,8 @@ type Workflow struct {
 	event       *eventsdk.Event
 	eventStream *eventsdk.Listener
 
-	execution *executionsdk.Execution
+	execution       *executionsdk.Execution
+	executionStream *executionsdk.Listener
 
 	ErrC chan error
 }
@@ -30,18 +32,35 @@ func New(event *eventsdk.Event, execution *executionsdk.Execution) *Workflow {
 
 // Start the workflow engine
 func (w *Workflow) Start() error {
-	if w.eventStream != nil {
+	if w.eventStream != nil || w.executionStream != nil {
 		return fmt.Errorf("workflow engine already running")
 	}
 	w.eventStream = w.event.GetStream(nil)
-	for event := range w.eventStream.C {
-		go w.processEvent(event)
+	w.executionStream = w.execution.GetStream(&executionsdk.Filter{
+		Statuses: []execution.Status{execution.Completed},
+	})
+	for {
+		select {
+		case event := <-w.eventStream.C:
+			go w.processEvent(event, Event)
+		case execution := <-w.executionStream.C:
+			eventHash, err := hash.Random()
+			if err != nil {
+				w.ErrC <- err
+			}
+			event := &event.Event{
+				Hash:         eventHash,
+				InstanceHash: execution.InstanceHash,
+				Key:          execution.TaskKey,
+				Data:         execution.Outputs,
+			}
+			go w.processEvent(event, Result)
+		}
 	}
-	return nil
 }
 
-func (w *Workflow) processEvent(event *event.Event) {
-	workflows, err := w.findMatchingWorkflows(event)
+func (w *Workflow) processEvent(event *event.Event, trigger triggerType) {
+	workflows, err := w.findMatchingWorkflows(event, trigger)
 	if err != nil {
 		w.ErrC <- err
 	}
@@ -54,14 +73,14 @@ func (w *Workflow) processEvent(event *event.Event) {
 	}
 }
 
-func (w *Workflow) findMatchingWorkflows(event *event.Event) ([]*workflow, error) {
+func (w *Workflow) findMatchingWorkflows(event *event.Event, trigger triggerType) ([]*workflow, error) {
 	all, err := all()
 	if err != nil {
 		return nil, err
 	}
 	workflows := make([]*workflow, 0)
 	for _, wf := range all {
-		if wf.Trigger.Match(event) {
+		if wf.Trigger.MatchEvent(event) {
 			workflows = append(workflows, wf)
 		}
 	}
@@ -80,7 +99,8 @@ func all() ([]*workflow, error) {
 	}
 	workflows = append(workflows, &workflow{
 		Trigger: trigger{
-			EventKey:     "eventX",
+			Key:          "taskX",
+			Type:         Result,
 			InstanceHash: instanceHash,
 			Filters: []*filter{
 				{Key: "bar", Predicate: EQ, Value: "world-2"},


### PR DESCRIPTION
The workflow is now listening to the following streams
- Events
- Executions (filtered by completed executions only)

If it receives a matching even, it creates an execution with the event hash and the event data
If it receives a matching execution, it creates an execution with the parent execution hash and the output of the parent execution

To test:

Current workflow implemented:
https://github.com/mesg-foundation/engine/blob/f35871959db3ed4925f4565b8007e3af66bd1a99/workflow/workflow.go#L95-L103

Service [here](https://github.com/mesg-foundation/engine/blob/f35871959db3ed4925f4565b8007e3af66bd1a99/workflow/workflow.go#L89)

- Create the service
- Listen for executions (do not start the service yet)
- Start the instance (with `--env EVENT_INTERVAL=0` to remove useless logs)

You should see 2 executions, one with the evenHash (event start) and the other with a parentHash (result of taskA)

You can trigger another one with
```mesg-cli service:execute test-workflow taskA --data a=hello```

And see again 2 executions, one from the CLI (with an eventHash) the second from the workflow (with an parentHash)