### PR TITLE
Log errors from the workflow as warning

### DIFF
--- a/core/main.go
+++ b/core/main.go
@@ -164,11 +164,16 @@ func main() {
 		}
 	}()
 
+	logrus.Info("starting workflow engine")
+	wf := workflow.New(dep.sdk.Event, dep.sdk.Execution)
 	go func() {
-		logrus.Info("starting workflow engine")
-		wf := workflow.New(dep.sdk.Event, dep.sdk.Execution)
 		if err := wf.Start(); err != nil {
 			logrus.Fatalln(err)
+		}
+	}()
+	go func() {
+		for err := range wf.ErrC {
+			logrus.Warn(err)
 		}
 	}()
 


### PR DESCRIPTION
Errors from the workflow are logged as a warning in the engine.
The kind of error that can occur:
- Error when fetching the workflow that matches an event/execution
- Error while creating the execution (wrong input, an instance that doesn't exist, ...)

These errors are not critical so I don't think it's useful to put them as error and warning might be enough but I'm, ok to change to error