### PR TITLE
Only restore go cache from the exact same go.sum file in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ restore_go_mod_cache: &restore_go_mod_cache
   - restore_cache:
       keys:
         - go-mod-cache-{{ checksum "go.sum" }}
-        - go-mod-cache
 save_go_mod_cache: &save_go_mod_cache
   - save_cache:
       key: go-mod-cache-{{ checksum "go.sum" }}


### PR DESCRIPTION
This PR make the go mod cache on CircleCI lighter by only restoring the cache for the exact same `go.sum` file.

Currently, if `go.sum` changed, then the cache of the previous `go.sum` will be used. This has the side effect to keep in cache ALL version of previously used packages. The cache is currently 1.1GB. [CircleCI recommend to keep it to 500MB](https://circleci.com/docs/2.0/caching/#cache-size) and take 27 seconds (more time than actually downloading the dep) instead of a few seconds to restore.