### PR TITLE
Possibility to enable/disable network when running the engine

### DIFF
--- a/core/main.go
+++ b/core/main.go
@@ -166,7 +166,7 @@ func main() {
 		if err != nil {
 			logrus.WithField("module", "main").Fatalln(err)
 		}
-		logrus.WithField("seeds", cfg.Tendermint.P2P.Seeds).Info("starting tendermint node")
+		logrus.WithField("module", "main").WithField("seeds", cfg.Tendermint.P2P.Seeds).Info("starting tendermint node")
 		if err := node.Start(); err != nil {
 			logrus.WithField("module", "main").Fatalln(err)
 		}

--- a/core/main.go
+++ b/core/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"flag"
 	"strconv"
 	"sync"
 
@@ -23,6 +24,8 @@ import (
 	"github.com/mesg-foundation/engine/x/xsignal"
 	"github.com/sirupsen/logrus"
 )
+
+var network = flag.Bool("experimental-network", false, "start the engine with the network")
 
 type dependencies struct {
 	cfg         *config.Config
@@ -143,6 +146,7 @@ func stopRunningServices(sdk *sdk.SDK) error {
 }
 
 func main() {
+	flag.Parse()
 	cfg, err := config.Global()
 	if err != nil {
 		logrus.Fatalln(err)
@@ -156,10 +160,16 @@ func main() {
 	// init logger.
 	logger.Init(cfg.Log.Format, cfg.Log.Level, cfg.Log.ForceColors)
 
-	// create tendermint node
-	node, err := tendermint.NewNode(cfg.Tendermint.Config, &cfg.Cosmos)
-	if err != nil {
-		logrus.Fatalln(err)
+	if *network {
+		// create tendermint node
+		node, err := tendermint.NewNode(cfg.Tendermint.Config, &cfg.Cosmos)
+		if err != nil {
+			logrus.WithField("module", "main").Fatalln(err)
+		}
+		log.WithField("seeds", cfg.Tendermint.P2P.Seeds).Info("starting tendermint node")
+		if err := node.Start(); err != nil {
+			logrus.WithField("module", "main").Fatalln(err)
+		}
 	}
 
 	// init system services.
@@ -177,11 +187,6 @@ func main() {
 			logrus.WithField("module", "main").Fatalln(err)
 		}
 	}()
-
-	logrus.WithField("module", "main").WithField("seeds", cfg.Tendermint.P2P.Seeds).Info("starting tendermint node")
-	if err := node.Start(); err != nil {
-		logrus.Fatalln(err)
-	}
 
 	logrus.WithField("module", "main").Info("starting workflow engine")
 	s := scheduler.New(dep.sdk.Event, dep.sdk.Execution, dep.sdk.Workflow)

--- a/core/main.go
+++ b/core/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"path/filepath"
 	"flag"
+	"path/filepath"
 	"strconv"
 	"sync"
 
@@ -166,7 +166,7 @@ func main() {
 		if err != nil {
 			logrus.WithField("module", "main").Fatalln(err)
 		}
-		log.WithField("seeds", cfg.Tendermint.P2P.Seeds).Info("starting tendermint node")
+		logrus.WithField("seeds", cfg.Tendermint.P2P.Seeds).Info("starting tendermint node")
 		if err := node.Start(); err != nil {
 			logrus.WithField("module", "main").Fatalln(err)
 		}

--- a/dev
+++ b/dev
@@ -155,6 +155,6 @@ docker service create \
   --network name=$TENDERMINT_NETWORK,alias=$TENDERMINT_NETWORK_ALIAS \
   --publish $MESG_SERVER_PORT:50052 \
   $TENDERMINT_VALIDATOR_PORT_PUBLISH \
-  mesg/engine:$VERSION
+  mesg/engine:$VERSION ./engine --experimental-network
 
 docker service logs --follow --raw $MESG_NAME


### PR DESCRIPTION
Now the engine has a flag `experimental-network` that is `false` by default.
When this flag is enabled the tendermint node is created and started. If not the engine starts without any network.

The `dev` script runs the engine with the flag but by default, the network will not be started. If we want to run the network we need to manually run the docker image with the flag `experimental-network`