### PR TITLE
Simplify cosmos keybase by just creating a NewMnemonic helper

### DIFF
--- a/cosmos/keybase.go
+++ b/cosmos/keybase.go
@@ -22,19 +22,12 @@ func NewKeybase(dir string) (*Keybase, error) {
 	return &Keybase{kb}, nil
 }
 
-// GenerateAccount creates an account.
-func (kb *Keybase) GenerateAccount(name, mnemonic, password string) (keys.Info, error) {
+// NewMnemonic returns a new mnemonic phrase.
+func (kn *Keybase) NewMnemonic() (string, error) {
 	// read entropy seed straight from crypto.Rand and convert to mnemonic
 	entropySeed, err := bip39.NewEntropy(mnemonicEntropySize)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-
-	if mnemonic == "" {
-		mnemonic, err = bip39.NewMnemonic(entropySeed)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return kb.CreateAccount(name, mnemonic, "", password, 0, 0)
+	return bip39.NewMnemonic(entropySeed)
 }

--- a/cosmos/node.go
+++ b/cosmos/node.go
@@ -26,7 +26,7 @@ func NewNode(app *App, kb *Keybase, cfg *tmconfig.Config, ccfg *config.CosmosCon
 	cdc := app.Cdc()
 
 	// generate first user
-	account, err := kb.GenerateAccount(ccfg.GenesisAccount.Name, ccfg.GenesisAccount.Mnemonic, ccfg.GenesisAccount.Password)
+	account, err := kb.CreateAccount(ccfg.GenesisAccount.Name, ccfg.GenesisAccount.Mnemonic, "", ccfg.GenesisAccount.Password, 0, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Simplify cosmos keybase by just creating a `NewMnemonic` helper instead of `GenerateAccount` (can use the default `CreateAccount` that offer more options).