### PR TITLE
Use Structs in the orchestrator

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/process"
-	"github.com/mesg-foundation/engine/protobuf/convert"
 	"github.com/mesg-foundation/engine/protobuf/types"
 	eventsdk "github.com/mesg-foundation/engine/sdk/event"
 	executionsdk "github.com/mesg-foundation/engine/sdk/execution"
@@ -50,21 +49,10 @@ func (s *Orchestrator) Start() error {
 	for {
 		select {
 		case event := <-s.eventStream.C:
-			data := make(map[string]interface{})
-			if err := convert.Marshal(event.Data, &data); err != nil {
-				s.ErrC <- err
-				continue
-			}
-
-			go s.execute(s.eventFilter(event), nil, event, data)
+			go s.execute(s.eventFilter(event), nil, event, event.Data)
 		case execution := <-s.executionStream.C:
-			outputs := make(map[string]interface{})
-			if err := convert.Marshal(execution.Outputs, &outputs); err != nil {
-				s.ErrC <- err
-				continue
-			}
-			go s.execute(s.resultFilter(execution), execution, nil, outputs)
-			go s.execute(s.dependencyFilter(execution), execution, nil, outputs)
+			go s.execute(s.resultFilter(execution), execution, nil, execution.Outputs)
+			go s.execute(s.dependencyFilter(execution), execution, nil, execution.Outputs)
 		}
 	}
 }
@@ -113,7 +101,7 @@ func (s *Orchestrator) findNodes(wf *process.Process, filter func(wf *process.Pr
 	})
 }
 
-func (s *Orchestrator) execute(filter func(wf *process.Process, node *process.Process_Node) (bool, error), exec *execution.Execution, event *event.Event, data map[string]interface{}) {
+func (s *Orchestrator) execute(filter func(wf *process.Process, node *process.Process_Node) (bool, error), exec *execution.Execution, event *event.Event, data *types.Struct) {
 	processes, err := s.process.List()
 	if err != nil {
 		s.ErrC <- err
@@ -128,7 +116,7 @@ func (s *Orchestrator) execute(filter func(wf *process.Process, node *process.Pr
 	}
 }
 
-func (s *Orchestrator) executeNode(wf *process.Process, n *process.Process_Node, exec *execution.Execution, event *event.Event, data map[string]interface{}) error {
+func (s *Orchestrator) executeNode(wf *process.Process, n *process.Process_Node, exec *execution.Execution, event *event.Event, data *types.Struct) error {
 	logrus.WithField("module", "orchestrator").
 		WithField("nodeID", n.ID()).
 		WithField("type", fmt.Sprintf("%T", n)).Debug("process process")
@@ -163,8 +151,8 @@ func (s *Orchestrator) executeNode(wf *process.Process, n *process.Process_Node,
 	return nil
 }
 
-func (s *Orchestrator) processMap(mapping *process.Process_Node_Map, wf *process.Process, exec *execution.Execution, data map[string]interface{}) (map[string]interface{}, error) {
-	result := make(map[string]interface{})
+func (s *Orchestrator) processMap(mapping *process.Process_Node_Map, wf *process.Process, exec *execution.Execution, data *types.Struct) (*types.Struct, error) {
+	result := &types.Struct{}
 	for _, output := range mapping.Outputs {
 		ref := output.GetRef()
 		if ref == nil {
@@ -181,15 +169,15 @@ func (s *Orchestrator) processMap(mapping *process.Process_Node_Map, wf *process
 			if err != nil {
 				return nil, err
 			}
-			result[output.Key] = value
+			result.Fields[output.Key] = value
 		} else {
-			result[output.Key] = data[ref.Key]
+			result.Fields[output.Key] = data.Fields[ref.Key]
 		}
 	}
 	return result, nil
 }
 
-func (s *Orchestrator) resolveInput(wfHash hash.Hash, exec *execution.Execution, nodeKey string, outputKey string) (interface{}, error) {
+func (s *Orchestrator) resolveInput(wfHash hash.Hash, exec *execution.Execution, nodeKey string, outputKey string) (*types.Value, error) {
 	if !wfHash.Equal(exec.ProcessHash) {
 		return nil, fmt.Errorf("reference's nodeKey not found")
 	}
@@ -201,16 +189,12 @@ func (s *Orchestrator) resolveInput(wfHash hash.Hash, exec *execution.Execution,
 		return s.resolveInput(wfHash, parent, nodeKey, outputKey)
 	}
 
-	outputs := make(map[string]interface{})
-	if err := convert.Marshal(exec.Outputs, &outputs); err != nil {
-		return nil, err
-	}
-
-	return outputs[outputKey], nil
+	return exec.Outputs.Fields[outputKey], nil
 }
 
-func (s *Orchestrator) processTask(task *process.Process_Node_Task, wf *process.Process, exec *execution.Execution, event *event.Event, data map[string]interface{}) error {
+func (s *Orchestrator) processTask(task *process.Process_Node_Task, wf *process.Process, exec *execution.Execution, event *event.Event, data *types.Struct) error {
 	var eventHash, execHash hash.Hash
+
 	if event != nil {
 		eventHash = event.Hash
 	}
@@ -218,11 +202,6 @@ func (s *Orchestrator) processTask(task *process.Process_Node_Task, wf *process.
 		execHash = exec.Hash
 	}
 
-	execData := &types.Struct{}
-	if err := convert.Unmarshal(data, execData); err != nil {
-		return err
-	}
-
-	_, err := s.execution.Execute(wf.Hash, task.InstanceHash, eventHash, execHash, task.Key, task.TaskKey, execData, nil)
+	_, err := s.execution.Execute(wf.Hash, task.InstanceHash, eventHash, execHash, task.Key, task.TaskKey, data, nil)
 	return err
 }

--- a/process/filter.go
+++ b/process/filter.go
@@ -1,7 +1,9 @@
 package process
 
+import "github.com/mesg-foundation/engine/protobuf/types"
+
 // Match returns true if the data match the current list of filters
-func (f Process_Node_Filter) Match(data map[string]interface{}) bool {
+func (f Process_Node_Filter) Match(data *types.Struct) bool {
 	for _, condition := range f.Conditions {
 		if !condition.Match(data) {
 			return false
@@ -12,7 +14,7 @@ func (f Process_Node_Filter) Match(data map[string]interface{}) bool {
 }
 
 // Match returns true the current filter matches the given data
-func (f Process_Node_Filter_Condition) Match(inputs map[string]interface{}) bool {
+func (f Process_Node_Filter_Condition) Match(data *types.Struct) bool {
 	return f.Predicate == Process_Node_Filter_Condition_EQ &&
-		inputs[f.Key] == f.Value
+		data.Fields[f.Key].GetStringValue() == f.Value
 }

--- a/process/filter_test.go
+++ b/process/filter_test.go
@@ -3,49 +3,119 @@ package process
 import (
 	"testing"
 
+	"github.com/mesg-foundation/engine/protobuf/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMatch(t *testing.T) {
 	var tests = []struct {
+		name   string
 		filter Process_Node_Filter
-		data   map[string]interface{}
+		data   *types.Struct
 		match  bool
 	}{
-		{ // not matching filter
-			filter: Process_Node_Filter{Conditions: []Process_Node_Filter_Condition{
-				{Key: "foo", Predicate: Process_Node_Filter_Condition_EQ, Value: "xx"},
-			}},
-			data:  map[string]interface{}{"foo": "bar"},
+		{
+			name: "not matching filter",
+			filter: Process_Node_Filter{
+				Conditions: []Process_Node_Filter_Condition{
+					{
+						Key:       "foo",
+						Predicate: Process_Node_Filter_Condition_EQ,
+						Value:     "xx",
+					},
+				},
+			},
+			data: &types.Struct{
+				Fields: map[string]*types.Value{
+					"foo": {
+						Kind: &types.Value_StringValue{
+							StringValue: "bar",
+						},
+					},
+				},
+			},
 			match: false,
 		},
-		{ // matching multiple conditions
-			filter: Process_Node_Filter{Conditions: []Process_Node_Filter_Condition{
-				{Key: "foo", Predicate: Process_Node_Filter_Condition_EQ, Value: "bar"},
-				{Key: "xxx", Predicate: Process_Node_Filter_Condition_EQ, Value: "yyy"},
-			}},
-			data: map[string]interface{}{
-				"foo": "bar",
-				"xxx": "yyy",
-				"aaa": "bbb",
+		{
+			name: "matching multiple conditions",
+			filter: Process_Node_Filter{
+				Conditions: []Process_Node_Filter_Condition{
+					{
+						Key:       "foo",
+						Predicate: Process_Node_Filter_Condition_EQ,
+						Value:     "bar",
+					},
+					{
+						Key:       "xxx",
+						Predicate: Process_Node_Filter_Condition_EQ,
+						Value:     "yyy",
+					},
+				},
+			},
+			data: &types.Struct{
+				Fields: map[string]*types.Value{
+					"foo": {
+						Kind: &types.Value_StringValue{
+							StringValue: "bar",
+						},
+					},
+					"xxx": {
+						Kind: &types.Value_StringValue{
+							StringValue: "yyy",
+						},
+					},
+					"aaa": {
+						Kind: &types.Value_StringValue{
+							StringValue: "bbb",
+						},
+					},
+				},
 			},
 			match: true,
 		},
-		{ // non matching multiple conditions
-			filter: Process_Node_Filter{Conditions: []Process_Node_Filter_Condition{
-				{Key: "foo", Predicate: Process_Node_Filter_Condition_EQ, Value: "bar"},
-				{Key: "xxx", Predicate: Process_Node_Filter_Condition_EQ, Value: "aaa"},
-			}},
-			data: map[string]interface{}{
-				"foo": "bar",
-				"xxx": "yyy",
-				"aaa": "bbb",
+		{
+			name: "non matching multiple conditions",
+			filter: Process_Node_Filter{
+				Conditions: []Process_Node_Filter_Condition{
+					{
+						Key:       "foo",
+						Predicate: Process_Node_Filter_Condition_EQ,
+						Value:     "bar",
+					},
+					{
+						Key:       "xxx",
+						Predicate: Process_Node_Filter_Condition_EQ,
+						Value:     "aaa",
+					},
+				},
+			},
+			data: &types.Struct{
+				Fields: map[string]*types.Value{
+					"foo": {
+						Kind: &types.Value_StringValue{
+							StringValue: "bar",
+						},
+					},
+					"xxx": {
+						Kind: &types.Value_StringValue{
+							StringValue: "yyy",
+						},
+					},
+					"aaa": {
+						Kind: &types.Value_StringValue{
+							StringValue: "bbb",
+						},
+					},
+				},
 			},
 			match: false,
 		},
 	}
-	for i, test := range tests {
-		match := test.filter.Match(test.data)
-		require.Equal(t, test.match, match, i)
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.match, tt.filter.Match(tt.data))
+		})
 	}
 }


### PR DESCRIPTION
dependency: https://github.com/mesg-foundation/engine/pull/1318

Fix issue with data comparison and replacement in the orchestrator due to the change from `map[string]interface{}` to `types.Struct`. The struct was unmarshalled as `map[string]interface{}` and so containing the struct of the `types.Struct` where our comparison was based on a simple map of value.