### PR TITLE
Add --exp to dev command

### DIFF
--- a/dev
+++ b/dev
@@ -4,8 +4,10 @@ set -e
 
 DIR=$(pwd)
 
-# network to connect multiple engine instances
-TENDERMINT_NETWORK="mesg-tendermint"
+# Flags
+if [[ $* == *--exp* ]]; then
+  EXPERIMENTAL_FLAGS+=" --experimental-network"
+fi
 
 # mesg config variables
 MESG_NAME=${MESG_NAME:-"engine"}
@@ -15,6 +17,8 @@ MESG_LOG_FORCECOLORS=${MESG_LOG_FORCECOLORS:-"false"}
 MESG_LOG_LEVEL=${MESG_LOG_LEVEL:-"debug"}
 MESG_SERVER_PORT=${MESG_SERVER_PORT:-"50052"}
 
+ # network to connect multiple engine instances
+TENDERMINT_NETWORK="mesg-tendermint"
 TENDERMINT_HOME_CONFIG="$MESG_PATH/tendermint"
 TENDERMINT_NETWORK_ALIAS=${TENDERMINT_NETWORK_ALIAS:-$MESG_NAME}
 TENDERMINT_VALIDATOR_NAME=${TENDERMINT_VALIDATOR_NAME:-"validator"}
@@ -155,6 +159,6 @@ docker service create \
   --network name=$TENDERMINT_NETWORK,alias=$TENDERMINT_NETWORK_ALIAS \
   --publish $MESG_SERVER_PORT:50052 \
   $TENDERMINT_VALIDATOR_PORT_PUBLISH \
-  mesg/engine:$VERSION ./engine --experimental-network
+  mesg/engine:$VERSION ./engine $EXPERIMENTAL_FLAGS
 
 docker service logs --follow --raw $MESG_NAME


### PR DESCRIPTION
It's REALLY annoying to deactivate the network by removing the flag in the dev script.
So now we can pass the flag `--experimental-network` to enable the network feature.
This is only a temp solution until the network is the default solution and fully implemented!

This PR is a simplified version of https://github.com/mesg-foundation/engine/pull/1262.

```bash
./dev # no network
./dev --exp # with network
./dev --exp --validator # with network and node is validator
```