### PR TITLE
Fix hash.Unmarshal when using proto.Unmarshal

### DIFF
--- a/database/process_db_test.go
+++ b/database/process_db_test.go
@@ -63,3 +63,35 @@ func TestProcessDB(t *testing.T) {
 		require.NoError(t, db.Delete(p.Hash))
 	})
 }
+
+func TestHashIsDifferent(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "process.db.test")
+	defer os.Remove(dir)
+
+	db, err := NewProcessDB(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	p1 := &process.Process{
+		Hash: hash.Int(1),
+		Key:  "1",
+	}
+
+	p2 := &process.Process{
+		Hash: hash.Int(2),
+		Key:  "2",
+	}
+
+	db.Save(p1)
+	db.Save(p2)
+
+	list, err := db.All()
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	require.Equal(t, list[0].Key, p1.Key)
+	require.Equal(t, list[0].Hash, p1.Hash)
+
+	require.Equal(t, list[1].Key, p2.Key)
+	require.Equal(t, list[1].Hash, p2.Hash)
+}

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -115,7 +115,8 @@ func (h Hash) MarshalTo(data []byte) (int, error) {
 
 // Unmarshal unmarshals slice of bytes into hash. It's used by protobuf.
 func (h *Hash) Unmarshal(data []byte) error {
-	*h = data
+	*h = make([]byte, len(data))
+	copy(*h, data)
 	return nil
 }
 

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -94,16 +94,10 @@ func TestUnmarshalJSON(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
-	var hashes []Hash
-	hashSameAddr := Int(1)
-	for i := 0; i < 10; i++ {
-		copy(hashSameAddr, Int(i))
-		var hash = Hash{}
-		assert.NoError(t, hash.Unmarshal(hashSameAddr))
-		assert.Equal(t, Int(i), hash)
-		hashes = append(hashes, hash)
-	}
-	for i := 0; i < 10; i++ {
-		assert.Equal(t, Int(i), hashes[i])
-	}
+	var hash Hash
+	data := []byte(Int(1))
+	hash.Unmarshal(data)
+	// check if unmarshal copy the data
+	// test if two slises do not share the same address
+	assert.True(t, &hash[cap(hash)-1] != &data[cap(data)-1])
 }

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -92,3 +92,18 @@ func TestUnmarshalJSON(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte("\"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM\""), &h))
 	assert.Equal(t, Int(1), h)
 }
+
+func TestUnmarshal(t *testing.T) {
+	var hashes []Hash
+	hashSameAddr := Int(1)
+	for i := 0; i < 10; i++ {
+		copy(hashSameAddr, Int(i))
+		var hash = Hash{}
+		assert.NoError(t, hash.Unmarshal(hashSameAddr))
+		assert.Equal(t, Int(i), hash)
+		hashes = append(hashes, hash)
+	}
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, Int(i), hashes[i])
+	}
+}


### PR DESCRIPTION
Fix `hash.Unmarshal` when using `proto.Unmarshal`.

The problem was `data []byte` is the same variable with the same address when using proto.Unmarshal.
Using it directly was causing all hashes to be reference the same memory thus the same hash.

Closes https://github.com/mesg-foundation/engine/issues/1330