### PR TITLE
Read config from file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ func defaultConfig() (*Config, error) {
 
 	c.Cosmos.RelativePath = "cosmos"
 
-	c.DevGenesis.AccountName = "engine"
+	c.DevGenesis.AccountName = "dev"
 	c.DevGenesis.AccountPassword = "pass"
 	c.DevGenesis.ChainID = "mesg-dev-chain"
 

--- a/config/config.go
+++ b/config/config.go
@@ -59,8 +59,8 @@ type Config struct {
 	}
 }
 
-// Default creates a new config with default values.
-func Default() (*Config, error) {
+// defaultConfig creates a new config with default values.
+func defaultConfig() (*Config, error) {
 	home, err := homedir.Dir()
 	if err != nil {
 		return nil, err
@@ -98,33 +98,33 @@ func Default() (*Config, error) {
 
 // New returns a Config after loaded ENV and validate the values.
 func New() (*Config, error) {
-	c, err := Default()
+	c, err := defaultConfig()
 	if err != nil {
 		return nil, err
 	}
-	if err := c.Load(); err != nil {
+	if err := c.load(); err != nil {
 		return nil, err
 	}
-	if err := c.Prepare(); err != nil {
+	if err := c.prepare(); err != nil {
 		return nil, err
 	}
-	if err := c.Validate(); err != nil {
+	if err := c.validate(); err != nil {
 		return nil, err
 	}
 	return c, nil
 }
 
-// Load reads config from environmental variables.
-func (c *Config) Load() error {
 	if err := envconfig.Process(envPrefix, c); err != nil {
 		return err
+// load reads config from environmental variables.
+func (c *Config) load() error {
 	}
 	c.Tendermint.Config.SetRoot(filepath.Join(c.Path, c.Tendermint.RelativePath))
 	return nil
 }
 
-// Prepare setups local directories or any other required thing based on config
-func (c *Config) Prepare() error {
+// prepare setups local directories or any other required thing based on config
+func (c *Config) prepare() error {
 	if err := os.MkdirAll(c.Path, os.FileMode(0755)); err != nil {
 		return err
 	}
@@ -140,8 +140,8 @@ func (c *Config) Prepare() error {
 	return nil
 }
 
-// Validate checks values and return an error if any validation failed.
-func (c *Config) Validate() error {
+// validate checks values and return an error if any validation failed.
+func (c *Config) validate() error {
 	if !xstrings.SliceContains([]string{"text", "json"}, c.Log.Format) {
 		return fmt.Errorf("config.Log.Format value %q is not an allowed", c.Log.Format)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -31,34 +31,34 @@ type Config struct {
 	Path string `validate:"required" yaml:"-"`
 
 	Server struct {
-		Address string `validate:"required" yaml:"address,omitempty"`
+		Address string `validate:"required"`
 	}
 
 	Log struct {
-		Format      string `validate:"required" yaml:"format,omitempty"`
-		ForceColors bool   `yaml:"forceColors,omitempty"`
-		Level       string `validate:"required" yaml:"level,omitempty"`
+		Format      string `validate:"required"`
+		ForceColors bool
+		Level       string `validate:"required"`
 	}
 
 	Database struct {
-		InstanceRelativePath  string `validate:"required" yaml:"instanceRelativePath,omitempty"`
-		ExecutionRelativePath string `validate:"required" yaml:"executionRelativePath,omitempty"`
-		ProcessRelativePath   string `validate:"required" yaml:"processRelativePath,omitempty"`
+		InstanceRelativePath  string `validate:"required"`
+		ExecutionRelativePath string `validate:"required"`
+		ProcessRelativePath   string `validate:"required"`
 	}
 
 	Tendermint struct {
-		Config       *tmconfig.Config `validate:"required" yaml:"config,omitempty"`
-		RelativePath string           `validate:"required" yaml:"relativePath,omitempty"`
+		Config       *tmconfig.Config `validate:"required"`
+		RelativePath string           `validate:"required"`
 	}
 
 	Cosmos struct {
-		RelativePath string `validate:"required" yaml:"relativePath,omitempty"`
+		RelativePath string `validate:"required"`
 	}
 
 	DevGenesis struct {
-		AccountName     string `validate:"required" yaml:"accountName,omitempty"`
-		AccountPassword string `validate:"required" yaml:"accountPassword,omitempty"`
-		ChainID         string `validate:"required" yaml:"chainID,omitempty"`
+		AccountName     string `validate:"required"`
+		AccountPassword string `validate:"required"`
+		ChainID         string `validate:"required"`
 	}
 }
 
@@ -133,7 +133,7 @@ func (c *Config) load() error {
 		if err != nil {
 			return err
 		}
-		if err := yaml.Unmarshal(b, c); err != nil {
+		if err := yaml.UnmarshalStrict(b, c); err != nil {
 			return err
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -44,8 +44,8 @@ type Config struct {
 	}
 
 	Tendermint struct {
-		*tmconfig.Config `validate:"required"`
 		RelativePath     string `validate:"required"`
+		Config       *tmconfig.Config `validate:"required"`
 	}
 
 	Cosmos struct {
@@ -84,8 +84,8 @@ func Default() (*Config, error) {
 	c.Tendermint.Config.P2P.AddrBookStrict = false
 	c.Tendermint.Config.P2P.AllowDuplicateIP = true
 	c.Tendermint.Config.Consensus.TimeoutCommit = 10 * time.Second
-	c.Tendermint.Instrumentation.Prometheus = true
-	c.Tendermint.Instrumentation.PrometheusListenAddr = "0.0.0.0:26660"
+	c.Tendermint.Config.Instrumentation.Prometheus = true
+	c.Tendermint.Config.Instrumentation.PrometheusListenAddr = "0.0.0.0:26660"
 
 	c.Cosmos.RelativePath = "cosmos"
 
@@ -119,7 +119,7 @@ func (c *Config) Load() error {
 	if err := envconfig.Process(envPrefix, c); err != nil {
 		return err
 	}
-	c.Tendermint.SetRoot(filepath.Join(c.Path, c.Tendermint.RelativePath))
+	c.Tendermint.Config.SetRoot(filepath.Join(c.Path, c.Tendermint.RelativePath))
 	return nil
 }
 
@@ -128,7 +128,7 @@ func (c *Config) Prepare() error {
 	if err := os.MkdirAll(c.Path, os.FileMode(0755)); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(c.Tendermint.GenesisFile()), os.FileMode(0755)); err != nil {
+	if err := os.MkdirAll(filepath.Dir(c.Tendermint.Config.GenesisFile()), os.FileMode(0755)); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(c.Tendermint.Config.DBDir(), os.FileMode(0755)); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/require"
@@ -26,33 +28,38 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, filepath.Join("database", "executions", executionDBVersion), c.Database.ExecutionRelativePath)
 	require.Equal(t, "engine", c.Name)
 }
+func TestEnv(t *testing.T) {
+	os.Setenv(envPathKey, "tempPath")
+	defer os.Unsetenv(envPathKey)
+	os.Setenv(envNameKey, "name")
+	defer os.Unsetenv(envNameKey)
+	c, err := New()
+	require.NoError(t, err)
+	require.Equal(t, "tempPath", c.Path)
+	require.Equal(t, "name", c.Name)
+}
 
-func TestLoad(t *testing.T) {
-	snapsnot := map[string]string{
-		"MESG_SERVER_ADDRESS":                 "",
-		"MESG_LOG_FORMAT":                     "",
-		"MESG_LOG_LEVEL":                      "",
-		"MESG_LOG_FORCECOLORS":                "",
-	}
-	for key := range snapsnot {
-		snapsnot[key] = os.Getenv(key)
-	}
-	defer func() {
-		for key, value := range snapsnot {
-			os.Setenv(key, value)
-		}
-	}()
+func TestLoadFromFile(t *testing.T) {
+	tempPath, _ := ioutil.TempDir("", "TestConfigLoad")
+	defer os.RemoveAll(tempPath)
+	os.Setenv(envPathKey, tempPath)
+	defer os.Unsetenv(envPathKey)
+	ioutil.WriteFile(filepath.Join(tempPath, defaultConfigFileName), []byte(`name: shouldNotReadThis
+path: shouldNotReadThis
+server:
+  address: :50050
+tendermint:
+  config:
+    consensus:
+      timeoutcommit: 1m6s
+`), 0644)
 
-	os.Setenv("MESG_SERVER_ADDRESS", "test_server_address")
-	os.Setenv("MESG_LOG_FORMAT", "test_log_format")
-	os.Setenv("MESG_LOG_LEVEL", "test_log_level")
-	os.Setenv("MESG_LOG_FORCECOLORS", "true")
-
-	require.Equal(t, "test_server_address", c.Server.Address)
-	require.Equal(t, "test_log_format", c.Log.Format)
-	require.Equal(t, "test_log_level", c.Log.Level)
-	require.Equal(t, true, c.Log.ForceColors)
-	require.Equal(t, "localhost", c.Tendermint.P2P.PersistentPeers)
 	// load
 	c, err := New()
+	require.NoError(t, err)
+	require.Equal(t, ":50050", c.Server.Address)
+	require.Equal(t, 66*time.Second, c.Tendermint.Config.Consensus.TimeoutCommit)
+	require.Equal(t, "tcp://0.0.0.0:26657", c.Tendermint.Config.RPC.ListenAddress)
+	require.Equal(t, tempPath, c.Path)
+	require.Equal(t, "engine", c.Name)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,9 +14,9 @@ func TestNew(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDefaultValue(t *testing.T) {
+func TestDefaultConfig(t *testing.T) {
 	home, _ := homedir.Dir()
-	c, err := Default()
+	c, err := New()
 	require.NoError(t, err)
 	require.Equal(t, ":50052", c.Server.Address)
 	require.Equal(t, "text", c.Log.Format)
@@ -48,11 +48,11 @@ func TestLoad(t *testing.T) {
 	os.Setenv("MESG_LOG_LEVEL", "test_log_level")
 	os.Setenv("MESG_LOG_FORCECOLORS", "true")
 
-	c, _ := Default()
-	c.Load()
 	require.Equal(t, "test_server_address", c.Server.Address)
 	require.Equal(t, "test_log_format", c.Log.Format)
 	require.Equal(t, "test_log_level", c.Log.Level)
 	require.Equal(t, true, c.Log.ForceColors)
 	require.Equal(t, "localhost", c.Tendermint.P2P.PersistentPeers)
+	// load
+	c, err := New()
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,6 @@ func TestLoad(t *testing.T) {
 		"MESG_LOG_FORMAT":                     "",
 		"MESG_LOG_LEVEL":                      "",
 		"MESG_LOG_FORCECOLORS":                "",
-		"MESG_TENDERMINT_P2P_PERSISTENTPEERS": "",
 	}
 	for key := range snapsnot {
 		snapsnot[key] = os.Getenv(key)
@@ -48,7 +47,6 @@ func TestLoad(t *testing.T) {
 	os.Setenv("MESG_LOG_FORMAT", "test_log_format")
 	os.Setenv("MESG_LOG_LEVEL", "test_log_level")
 	os.Setenv("MESG_LOG_FORCECOLORS", "true")
-	os.Setenv("MESG_TENDERMINT_P2P_PERSISTENTPEERS", "localhost")
 
 	c, _ := Default()
 	c.Load()

--- a/core/main.go
+++ b/core/main.go
@@ -77,17 +77,17 @@ func stopRunningServices(sdk *enginesdk.SDK) error {
 }
 
 func loadOrGenDevGenesis(app *cosmos.App, kb *cosmos.Keybase, cfg *config.Config) (*tmtypes.GenesisDoc, error) {
-	if cosmos.GenesisExist(cfg.Tendermint.GenesisFile()) {
-		return cosmos.LoadGenesis(cfg.Tendermint.GenesisFile())
+	if cosmos.GenesisExist(cfg.Tendermint.Config.GenesisFile()) {
+		return cosmos.LoadGenesis(cfg.Tendermint.Config.GenesisFile())
 	}
 	// generate dev genesis
 	logrus.WithField("module", "main").Warn("Genesis file not found. Will generate an unsecured developer one.")
 	validator, err := cosmos.NewGenesisValidator(kb,
 		cfg.DevGenesis.AccountName,
 		cfg.DevGenesis.AccountPassword,
-		cfg.Tendermint.PrivValidatorKeyFile(),
-		cfg.Tendermint.PrivValidatorStateFile(),
-		cfg.Tendermint.NodeKeyFile(),
+		cfg.Tendermint.Config.PrivValidatorKeyFile(),
+		cfg.Tendermint.Config.PrivValidatorStateFile(),
+		cfg.Tendermint.Config.NodeKeyFile(),
 	)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func loadOrGenDevGenesis(app *cosmos.App, kb *cosmos.Keybase, cfg *config.Config
 		"nodeID":   validator.NodeID,
 		"peer":     fmt.Sprintf("%s@%s:26656", validator.NodeID, validator.Name),
 	}).Warnln("Dev validator")
-	return cosmos.GenGenesis(app.Cdc(), kb, app.DefaultGenesis(), cfg.DevGenesis.ChainID, cfg.Tendermint.GenesisFile(), []cosmos.GenesisValidator{validator})
+	return cosmos.GenGenesis(app.Cdc(), kb, app.DefaultGenesis(), cfg.DevGenesis.ChainID, cfg.Tendermint.Config.GenesisFile(), []cosmos.GenesisValidator{validator})
 }
 
 func main() {
@@ -169,7 +169,7 @@ func main() {
 	sdk := enginesdk.New(client, app.Cdc(), kb, c, instanceDB, executionDB, processDB, cfg.Name, strconv.Itoa(port))
 
 	// start tendermint node
-	logrus.WithField("module", "main").WithField("seeds", cfg.Tendermint.P2P.Seeds).Info("starting tendermint node")
+	logrus.WithField("module", "main").WithField("seeds", cfg.Tendermint.Config.P2P.Seeds).Info("starting tendermint node")
 	if err := node.Start(); err != nil {
 		logrus.WithField("module", "main").Fatalln(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Masterminds/sprig v2.20.0+incompatible // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/Microsoft/hcsshim v0.8.6 // indirect
-	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/btcsuite/btcd v0.0.0-20190807005414-4063feeff79a // indirect
 	github.com/containerd/containerd v1.3.0 // indirect
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
@@ -31,7 +30,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
-	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/lyft/protoc-gen-validate v0.1.0 // indirect
@@ -69,6 +67,7 @@ require (
 	google.golang.org/grpc v1.23.1
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.29.1
+	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiU
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.8.6 h1:ZfF0+zZeYdzMIVMZHKtDKJvLHj76XCuVae/jNkjj0IA=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
-github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
-github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
@@ -83,12 +81,8 @@ github.com/docker/cli v0.0.0-20191011045415-5d85cdacd257 h1:CtCb3w4JnCpPuhlQ1sot
 github.com/docker/cli v0.0.0-20191011045415-5d85cdacd257/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v0.0.0-20180803200506-eeea12db7a65 h1:WeqSIzsb30/sarqEph9RS+6xw8rmRpCACwV8+cJ1Rkc=
-github.com/docker/docker v0.0.0-20180803200506-eeea12db7a65/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.4.2-0.20191006173954-0abbb9e4ebf1 h1:FlyqqgbnhlpvsNPqXTdzxngEz/O0JxdMdb0AkfSQiOc=
 github.com/docker/docker v1.4.2-0.20191006173954-0abbb9e4ebf1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
-github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
@@ -188,8 +182,6 @@ github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlT
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY8LyvN8BXNM=
-github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,11 +5,9 @@ set -e
 # mesg config variables
 MESG_NAME=${MESG_NAME:-"engine"}
 MESG_PATH=${MESG_PATH:-"$HOME/.mesg"}
-MESG_LOG_FORMAT=${MESG_LOG_FORMAT:-"text"}
-MESG_LOG_FORCECOLORS=${MESG_LOG_FORCECOLORS:-"false"}
-MESG_LOG_LEVEL=${MESG_LOG_LEVEL:-"debug"}
-MESG_SERVER_PORT=${MESG_SERVER_PORT:-"50052"}
+
 MESG_TENDERMINT_NETWORK="mesg-tendermint"
+MESG_SERVER_PORT=${MESG_SERVER_PORT:-"50052"}
 MESG_TENDERMINT_PORT=${MESG_TENDERMINT_PORT:-"26656"}
 
 function onexit {
@@ -58,10 +56,6 @@ docker service create \
   --label com.docker.stack.namespace=$MESG_NAME \
   --label com.docker.stack.image=mesg/engine:local \
   --env MESG_NAME=$MESG_NAME \
-  --env MESG_LOG_FORMAT=$MESG_LOG_FORMAT \
-  --env MESG_LOG_FORCECOLORS=$MESG_LOG_FORCECOLORS \
-  --env MESG_LOG_LEVEL=$MESG_LOG_LEVEL \
-  --env MESG_TENDERMINT_P2P_PERSISTENTPEERS=$MESG_TENDERMINT_P2P_PERSISTENTPEERS \
   --mount type=bind,source=/var/run/docker.sock,destination=/var/run/docker.sock \
   --mount type=bind,source=$MESG_PATH,destination=/root/.mesg \
   --network $MESG_NAME \


### PR DESCRIPTION
This PR switch the config from env based to file base (closes https://github.com/mesg-foundation/engine/issues/1398).

If a file exist in `~/.mesg/config.yml`, it will be read and override the default config.
Example of file:
```yaml
tendermint:
  config:
    consensus:
      timeoutcommit: 1s
```

The config name and path cannot be overridden by the config file but still by env (`MESG_NAME` and `MESG_PATH`). The reason is those 2 config needs to be injected to docker at the creation of the docker service and thus should be injected to the engine at the same time (see dev script).

I also changed the tendermint config from embedded to dedicated variable for separation of concern and clarity. The yaml parsing needs to explicitly set the `config` key, so it was weird to have it only in yaml and not all the time.

Also, i changed the default dev genesis account name to `dev` instead of `engine`.