### PR TITLE
Update golangci-lint v1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
 
   "lint":
     docker:
-      - image: golangci/golangci-lint:v1.18
+      - image: golangci/golangci-lint:v1.21
     environment:
       - GOCACHE: *go_cache_dir
     steps:


### PR DESCRIPTION
Changelog: https://github.com/golangci/golangci-lint/releases

I think we should deactivate `wsl`, setup `gocognit` properly, understand what `stylecheck` is saying, remove `TODO` from the codebase or maybe (if possible) display them as warning instead of error.