### PR TITLE
Remove public error AlreadyExistsError from SDKs

### DIFF
--- a/sdk/process/process.go
+++ b/sdk/process/process.go
@@ -1,7 +1,7 @@
 package processesdk
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/mesg-foundation/engine/database"
 	"github.com/mesg-foundation/engine/hash"
@@ -46,7 +46,7 @@ func (w *Process) Create(wf *process.Process) (*process.Process, error) {
 
 	// check if process already exists.
 	if _, err := w.processDB.Get(wf.Hash); err == nil {
-		return nil, &AlreadyExistsError{Hash: wf.Hash}
+		return nil, errors.New("process %q already exists" + wf.Hash.String())
 	}
 
 	if err := wf.Validate(); err != nil {
@@ -68,13 +68,4 @@ func (w *Process) Get(hash hash.Hash) (*process.Process, error) {
 // List returns all processes.
 func (w *Process) List() ([]*process.Process, error) {
 	return w.processDB.All()
-}
-
-// AlreadyExistsError is an not found error.
-type AlreadyExistsError struct {
-	Hash hash.Hash
-}
-
-func (e *AlreadyExistsError) Error() string {
-	return fmt.Sprintf("process %q already exists", e.Hash.String())
 }

--- a/sdk/service/backend.go
+++ b/sdk/service/backend.go
@@ -123,7 +123,7 @@ func create(db *database.ServiceDB, req *api.CreateServiceRequest, owner cosmost
 
 	// check if service already exists.
 	if _, err := db.Get(srv.Hash); err == nil {
-		return nil, &AlreadyExistsError{Hash: srv.Hash}
+		return nil, errors.New("service %q already exists" + srv.Hash.String())
 	}
 
 	// TODO: the following test should be moved in New function

--- a/sdk/service/type.go
+++ b/sdk/service/type.go
@@ -1,8 +1,6 @@
 package servicesdk
 
 import (
-	"fmt"
-
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/service"
@@ -15,13 +13,4 @@ type Service interface {
 	List() ([]*service.Service, error)
 	Exists(hash hash.Hash) (bool, error)
 	Hash(req *api.CreateServiceRequest) (hash.Hash, error)
-}
-
-// AlreadyExistsError is an not found error.
-type AlreadyExistsError struct {
-	Hash hash.Hash
-}
-
-func (e *AlreadyExistsError) Error() string {
-	return fmt.Sprintf("service %q already exists", e.Hash.String())
 }


### PR DESCRIPTION
Simple PR to remove ALL public error `AlreadyExistsError` from SDKs