### PR TITLE
Increase gas limit tx

### DIFF
--- a/cosmos/txbuilder.go
+++ b/cosmos/txbuilder.go
@@ -22,7 +22,7 @@ func NewTxBuilder(accNumber, accSeq uint64, kb keys.Keybase, chainID string) TxB
 			authutils.GetTxEncoder(codec.Codec),
 			accNumber,
 			accSeq,
-			flags.DefaultGasLimit,
+			1000000,
 			flags.DefaultGasAdjustment,
 			true,
 			chainID,


### PR DESCRIPTION
Increase the gas limit used by tx builder to 1,000,000. The previously 200,000 limit is too small.

Dependent on https://github.com/mesg-foundation/engine/pull/1480