### PR TITLE
Add account.mnemonic in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/cosmos/go-bip39"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	tmconfig "github.com/tendermint/tendermint/config"
@@ -63,6 +64,7 @@ type Config struct {
 	Account struct {
 		Name     string `validate:"required"`
 		Password string `validate:"required"`
+		Mnemonic string
 	}
 }
 
@@ -170,8 +172,12 @@ func (c *Config) validate() error {
 	if _, err := logrus.ParseLevel(c.Log.Level); err != nil {
 		return fmt.Errorf("config.Log.Level error: %w", err)
 	}
+	if c.Account.Mnemonic != "" && !bip39.IsMnemonicValid(c.Account.Mnemonic) {
+		return fmt.Errorf("config.Account.Mnemonic error: mnemonic is not valid")
+	}
 	if err := c.Tendermint.Config.ValidateBasic(); err != nil {
 		return fmt.Errorf("config.Tendermint error: %w", err)
 	}
+
 	return validator.New().Struct(c)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,7 +28,10 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, filepath.Join(home, ".mesg"), c.Path)
 	require.Equal(t, filepath.Join("database", "executions", executionDBVersion), c.Database.ExecutionRelativePath)
 	require.Equal(t, "engine", c.Name)
+	require.Equal(t, "engine", c.Account.Name)
+	require.Equal(t, "pass", c.Account.Password)
 }
+
 func TestEnv(t *testing.T) {
 	os.Setenv(envPathKey, "tempPath")
 	defer os.Unsetenv(envPathKey)
@@ -56,6 +59,8 @@ func TestLoadFromFile(t *testing.T) {
   address: :50050
 log:
   forcecolors: true
+account:
+  mnemonic: glimpse upon body vast economy give taxi yellow rabbit come click ranch chronic hammer sport near rotate charge lumber chicken cloud base thing forum
 tendermint:
   config:
     consensus:

--- a/core/main.go
+++ b/core/main.go
@@ -74,6 +74,10 @@ func stopRunningServices(sdk *enginesdk.SDK, cfg *config.Config, address string)
 }
 
 func loadOrGenConfigAccount(kb *cosmos.Keybase, cfg *config.Config) (keys.Info, error) {
+	if cfg.Account.Mnemonic != "" {
+		return kb.CreateAccount(cfg.Account.Name, cfg.Account.Mnemonic, "", cfg.Account.Password, 0, 0)
+	}
+
 	exist, err := kb.Exist(cfg.Account.Name)
 	if err != nil {
 		return nil, err

--- a/core/main.go
+++ b/core/main.go
@@ -75,6 +75,7 @@ func stopRunningServices(sdk *enginesdk.SDK, cfg *config.Config, address string)
 
 func loadOrGenConfigAccount(kb *cosmos.Keybase, cfg *config.Config) (keys.Info, error) {
 	if cfg.Account.Mnemonic != "" {
+		logrus.WithField("module", "main").Warn("Config account mnemonic presents. Generating account with it...")
 		return kb.CreateAccount(cfg.Account.Name, cfg.Account.Mnemonic, "", cfg.Account.Password, 0, 0)
 	}
 

--- a/e2e/testdata/e2e.config.yml
+++ b/e2e/testdata/e2e.config.yml
@@ -1,6 +1,10 @@
 log:
   level: fatal
 
+account:
+  mnemonic: glimpse upon body vast economy give taxi yellow rabbit come click ranch chronic hammer sport near rotate charge lumber chicken cloud base thing forum
+
+
 tendermint:
   config:
     consensus:


### PR DESCRIPTION
- generate account based on mnemonic
- use the same account in e2e tests

close https://github.com/mesg-foundation/engine/issues/1470
