### PR TITLE
Customize cosmos config for mesg engine

### DIFF
--- a/core/main.go
+++ b/core/main.go
@@ -132,6 +132,9 @@ func main() {
 	if err != nil {
 		logrus.WithField("module", "main").Fatalln(err)
 	}
+
+	cosmos.CustomizeConfig()
+
 	// TODO: rename NewAppFactory to something else
 	appFactory := cosmos.NewAppFactory(logger.TendermintLogger(), db)
 

--- a/cosmos/config.go
+++ b/cosmos/config.go
@@ -37,6 +37,7 @@ const (
 	Bech32PrefixConsPub = Bech32MainPrefix + PrefixValidator + PrefixConsensus + PrefixPublic
 )
 
+// CustomizeConfig customizes the cosmos application like addresses prefixes and coin type
 func CustomizeConfig() {
 	config := sdktypes.GetConfig()
 	config.SetBech32PrefixForAccount(Bech32PrefixAccAddr, Bech32PrefixAccPub)

--- a/cosmos/config.go
+++ b/cosmos/config.go
@@ -1,0 +1,47 @@
+package cosmos
+
+import sdktypes "github.com/cosmos/cosmos-sdk/types"
+
+const (
+	// CoinType is a mesg coin type.
+	CoinType = 50000
+
+	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
+	Bech32MainPrefix = "mesgtest"
+
+	// PrefixAccount is the prefix for account keys
+	PrefixAccount = "acc"
+	// PrefixValidator is the prefix for validator keys
+	PrefixValidator = "val"
+	// PrefixConsensus is the prefix for consensus keys
+	PrefixConsensus = "cons"
+	// PrefixPublic is the prefix for public keys
+	PrefixPublic = "pub"
+	// PrefixOperator is the prefix for operator keys
+	PrefixOperator = "oper"
+
+	// PrefixAddress is the prefix for addresses
+	PrefixAddress = "addr"
+
+	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
+	Bech32PrefixAccAddr = Bech32MainPrefix
+	// Bech32PrefixAccPub defines the Bech32 prefix of an account's public key
+	Bech32PrefixAccPub = Bech32MainPrefix + PrefixPublic
+	// Bech32PrefixValAddr defines the Bech32 prefix of a validator's operator address
+	Bech32PrefixValAddr = Bech32MainPrefix + PrefixValidator + PrefixOperator
+	// Bech32PrefixValPub defines the Bech32 prefix of a validator's operator public key
+	Bech32PrefixValPub = Bech32MainPrefix + PrefixValidator + PrefixOperator + PrefixPublic
+	// Bech32PrefixConsAddr defines the Bech32 prefix of a consensus node address
+	Bech32PrefixConsAddr = Bech32MainPrefix + PrefixValidator + PrefixConsensus
+	// Bech32PrefixConsPub defines the Bech32 prefix of a consensus node public key
+	Bech32PrefixConsPub = Bech32MainPrefix + PrefixValidator + PrefixConsensus + PrefixPublic
+)
+
+func CustomizeConfig() {
+	config := sdktypes.GetConfig()
+	config.SetBech32PrefixForAccount(Bech32PrefixAccAddr, Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(Bech32PrefixValAddr, Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(Bech32PrefixConsAddr, Bech32PrefixConsPub)
+	config.SetCoinType(CoinType)
+	config.Seal()
+}

--- a/cosmos/config.go
+++ b/cosmos/config.go
@@ -6,7 +6,7 @@ const (
 	// CoinType is a mesg coin type.
 	CoinType = 50000
 
-	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
+	// Bech32MainPrefix defines the main Bech32 prefix
 	Bech32MainPrefix = "mesgtest"
 
 	// PrefixAccount is the prefix for account keys


### PR DESCRIPTION
close #1571 

Modified address for cosmos config (see: https://github.com/cosmos/cosmos-sdk/blob/master//types/address.go#L18-L69)

Also, we should reserve a code for mesg tokens according to https://github.com/satoshilabs/slips/blob/master/slip-0044.md