### PR TITLE
Dump config when started

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -125,7 +125,13 @@ func New() (*Config, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
-	return c, nil
+
+	res, err := yaml.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, ioutil.WriteFile(filepath.Join(c.Path, defaultConfigFileName), res, 0644)
 }
 
 // load reads config from environmental variables.


### PR DESCRIPTION
This PR writes the full configs in the `config.yml` once loaded.
This helps to edit the config needed. I had a hard time trying to figure out the format/case for some configs like cors or prometheus so I had to dump the config.

What do you think about doing that by default in the engine?