### PR TITLE
Move AccNumber and AccIndex to the config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	Account struct {
 		Name     string `validate:"required"`
 		Password string `validate:"required"`
+		Number   uint32
+		Index    uint32
 		Mnemonic string
 	}
 }
@@ -97,6 +99,8 @@ func defaultConfig() (*Config, error) {
 
 	c.Account.Name = "engine"
 	c.Account.Password = "pass"
+	c.Account.Number = uint32(0)
+	c.Account.Index = uint32(0)
 
 	return &c, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,8 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, "engine", c.Name)
 	require.Equal(t, "engine", c.Account.Name)
 	require.Equal(t, "pass", c.Account.Password)
+	require.Equal(t, uint32(0), c.Account.Number)
+	require.Equal(t, uint32(0), c.Account.Index)
 }
 
 func TestEnv(t *testing.T) {

--- a/core/main.go
+++ b/core/main.go
@@ -62,7 +62,7 @@ func stopRunningServices(sdk *enginesdk.SDK, address string) error {
 func loadOrGenConfigAccount(kb *cosmos.Keybase, cfg *config.Config) (keys.Info, error) {
 	if cfg.Account.Mnemonic != "" {
 		logrus.WithField("module", "main").Warn("Config account mnemonic presents. Generating account with it...")
-		return kb.CreateAccount(cfg.Account.Name, cfg.Account.Mnemonic, "", cfg.Account.Password, cosmos.AccNumber, cosmos.AccIndex)
+		return kb.CreateAccount(cfg.Account.Name, cfg.Account.Mnemonic, "", cfg.Account.Password, cfg.Account.Number, cfg.Account.Index)
 	}
 
 	exist, err := kb.Exist(cfg.Account.Name)
@@ -82,7 +82,7 @@ func loadOrGenConfigAccount(kb *cosmos.Keybase, cfg *config.Config) (keys.Info, 
 		"password": cfg.Account.Password,
 		"mnemonic": mnemonic,
 	}).Warn("Account")
-	return kb.CreateAccount(cfg.Account.Name, mnemonic, "", cfg.Account.Password, cosmos.AccNumber, cosmos.AccIndex)
+	return kb.CreateAccount(cfg.Account.Name, mnemonic, "", cfg.Account.Password, cfg.Account.Number, cfg.Account.Index)
 }
 
 func loadOrGenDevGenesis(app *cosmos.App, kb *cosmos.Keybase, cfg *config.Config) (*tmtypes.GenesisDoc, error) {

--- a/cosmos/genesis_test.go
+++ b/cosmos/genesis_test.go
@@ -40,7 +40,7 @@ func TestGenesis(t *testing.T) {
 	)
 	// init account
 	mnemonic, _ := kb.NewMnemonic()
-	kb.CreateAccount(name, mnemonic, "", password, AccNumber, AccIndex)
+	kb.CreateAccount(name, mnemonic, "", password, 0, 0)
 	// start tests
 	t.Run("generate validator", func(t *testing.T) {
 		v, err := NewGenesisValidator(kb, name, password, privValidatorKeyFile, privValidatorStateFile, nodeKeyFile)

--- a/cosmos/keybase.go
+++ b/cosmos/keybase.go
@@ -12,14 +12,7 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 )
 
-const (
-	// AccNumber is the account number of the account in keybase.
-	AccNumber = 0
-	// AccIndex is the account index of the account in keybase.
-	AccIndex = 0
-
-	mnemonicEntropySize = 256
-)
+const mnemonicEntropySize = 256
 
 // Keybase is a standard cosmos keybase.
 type Keybase struct {

--- a/cosmos/keybase_test.go
+++ b/cosmos/keybase_test.go
@@ -26,7 +26,7 @@ func TestKeybase(t *testing.T) {
 	})
 
 	t.Run("Create", func(t *testing.T) {
-		acc, err := kb.CreateAccount(name, mnemonic, "", password, AccNumber, AccIndex)
+		acc, err := kb.CreateAccount(name, mnemonic, "", password, 0, 0)
 		require.NoError(t, err)
 		require.Equal(t, name, acc.GetName())
 	})


### PR DESCRIPTION
Now that the cosmos package doesn't use these constants, these constants are not necessary anymore and can be moved to the config