### PR TITLE
Change default path for the engine

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -4,7 +4,7 @@ set -e
 
 # mesg config variables
 MESG_NAME=${MESG_NAME:-"engine"}
-MESG_PATH=${MESG_PATH:-"$HOME/.mesg"}
+MESG_PATH=${MESG_PATH:-"$HOME/.mesg/mesg-dev-chain"}
 
 MESG_SERVER_PORT=${MESG_SERVER_PORT:-"50052"}
 MESG_TENDERMINT_NETWORK="mesg-tendermint"


### PR DESCRIPTION
This allows us to store in the same `.mesg` multiple networks. With the dev script we write on the dev chain but we could run the testnet still in the same `.mesg` directory