### PR TITLE
Force encoding in json everywhere in the engine

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -32,13 +32,3 @@ func UnmarshalJSON(bz []byte, ptr interface{}) error {
 	}
 	return Codec.UnmarshalJSON(bz, ptr)
 }
-
-// UnmarshalBinaryBare https://godoc.org/github.com/tendermint/go-amino#Codec.UnmarshalBinaryBare
-func UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
-	return UnmarshalJSON(bz, ptr)
-}
-
-// MarshalBinaryBare https://godoc.org/github.com/tendermint/go-amino#Codec.MarshalBinaryBare
-func MarshalBinaryBare(o interface{}) ([]byte, error) {
-	return MarshalJSON(o)
-}

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -27,15 +27,18 @@ func MarshalJSON(o interface{}) ([]byte, error) {
 
 // UnmarshalJSON https://godoc.org/github.com/tendermint/go-amino#Codec.UnmarshalJSON
 func UnmarshalJSON(bz []byte, ptr interface{}) error {
+	if len(bz) == 0 {
+		return nil
+	}
 	return Codec.UnmarshalJSON(bz, ptr)
 }
 
 // UnmarshalBinaryBare https://godoc.org/github.com/tendermint/go-amino#Codec.UnmarshalBinaryBare
 func UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
-	return Codec.UnmarshalBinaryBare(bz, ptr)
+	return UnmarshalJSON(bz, ptr)
 }
 
 // MarshalBinaryBare https://godoc.org/github.com/tendermint/go-amino#Codec.MarshalBinaryBare
 func MarshalBinaryBare(o interface{}) ([]byte, error) {
-	return Codec.MarshalBinaryBare(o)
+	return MarshalJSON(o)
 }

--- a/cosmos/client.go
+++ b/cosmos/client.go
@@ -53,7 +53,7 @@ func NewClient(node *node.Node, kb keys.Keybase, chainID, accName, accPassword, 
 func (c *Client) Query(path string, qdata, ptr interface{}) error {
 	var data []byte
 	if !xreflect.IsNil(qdata) {
-		b, err := codec.MarshalBinaryBare(qdata)
+		b, err := codec.MarshalJSON(qdata)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func (c *Client) Query(path string, qdata, ptr interface{}) error {
 	if err != nil {
 		return err
 	}
-	return codec.UnmarshalBinaryBare(result, ptr)
+	return codec.UnmarshalJSON(result, ptr)
 }
 
 // QueryWithData performs a query to a Tendermint node with the provided path

--- a/cosmos/module.go
+++ b/cosmos/module.go
@@ -151,7 +151,7 @@ func (m AppModule) NewQuerierHandler() cosmostypes.Querier {
 			}
 			return nil, NewMesgWrapError(CodeInternal, err)
 		}
-		res, err := codec.MarshalBinaryBare(data)
+		res, err := codec.MarshalJSON(data)
 		if err != nil {
 			return nil, NewMesgWrapError(CodeInternal, err)
 		}

--- a/protobuf/types/struct_test.go
+++ b/protobuf/types/struct_test.go
@@ -84,16 +84,16 @@ func TestStructMarshal(t *testing.T) {
 		structUnm2       *Struct
 	)
 	t.Run("Marshal", func(t *testing.T) {
-		structValueSort1, err = codec.MarshalBinaryBare(structSort1)
+		structValueSort1, err = codec.MarshalJSON(structSort1)
 		require.NoError(t, err)
-		structValueSort2, err = codec.MarshalBinaryBare(structSort2)
+		structValueSort2, err = codec.MarshalJSON(structSort2)
 		require.NoError(t, err)
 		require.True(t, hash.Dump(structValueSort1).Equal(hash.Dump(structValueSort2)))
 	})
 	t.Run("Unmarshal", func(t *testing.T) {
-		require.NoError(t, codec.UnmarshalBinaryBare(structValueSort1, &structUnm1))
+		require.NoError(t, codec.UnmarshalJSON(structValueSort1, &structUnm1))
 		require.True(t, structSort1.Equal(structUnm1))
-		require.NoError(t, codec.UnmarshalBinaryBare(structValueSort2, &structUnm2))
+		require.NoError(t, codec.UnmarshalJSON(structValueSort2, &structUnm2))
 		require.True(t, structSort2.Equal(structUnm2))
 		require.True(t, structUnm1.Equal(structUnm2))
 	})

--- a/sdk/execution/backend.go
+++ b/sdk/execution/backend.go
@@ -121,7 +121,7 @@ func (s *Backend) Create(request cosmostypes.Request, msg msgCreateExecution) (*
 	if err := exec.Execute(); err != nil {
 		return nil, err
 	}
-	value, err := codec.MarshalBinaryBare(exec)
+	value, err := codec.MarshalJSON(exec)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (s *Backend) Update(request cosmostypes.Request, msg msgUpdateExecution) (*
 		return nil, fmt.Errorf("execution %q doesn't exist", msg.Request.Hash)
 	}
 	var exec *execution.Execution
-	if err := codec.UnmarshalBinaryBare(store.Get(msg.Request.Hash), &exec); err != nil {
+	if err := codec.UnmarshalJSON(store.Get(msg.Request.Hash), &exec); err != nil {
 		return nil, err
 	}
 	switch res := msg.Request.Result.(type) {
@@ -156,7 +156,7 @@ func (s *Backend) Update(request cosmostypes.Request, msg msgUpdateExecution) (*
 	default:
 		return nil, errors.New("no execution result supplied")
 	}
-	value, err := codec.MarshalBinaryBare(exec)
+	value, err := codec.MarshalJSON(exec)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (s *Backend) Get(request cosmostypes.Request, hash hash.Hash) (*execution.E
 	if !store.Has(hash) {
 		return nil, fmt.Errorf("execution %q not found", hash)
 	}
-	return exec, codec.UnmarshalBinaryBare(store.Get(hash), &exec)
+	return exec, codec.UnmarshalJSON(store.Get(hash), &exec)
 }
 
 // List returns all executions.
@@ -196,7 +196,7 @@ func (s *Backend) List(request cosmostypes.Request) ([]*execution.Execution, err
 	for iter.Valid() {
 		var exec *execution.Execution
 		value := iter.Value()
-		if err := codec.UnmarshalBinaryBare(value, &exec); err != nil {
+		if err := codec.UnmarshalJSON(value, &exec); err != nil {
 			return nil, err
 		}
 		execs = append(execs, exec)

--- a/sdk/instance/backend.go
+++ b/sdk/instance/backend.go
@@ -47,7 +47,7 @@ func (s *Backend) querier(request cosmostypes.Request, path []string, req abci.R
 		return s.Get(request, hash)
 	case "list":
 		var f api.ListInstanceRequest_Filter
-		if err := codec.UnmarshalBinaryBare(req.Data, &f); err != nil {
+		if err := codec.UnmarshalJSON(req.Data, &f); err != nil {
 			return nil, err
 		}
 		return s.List(request, &f)
@@ -71,7 +71,7 @@ func (s *Backend) FetchOrCreate(request cosmostypes.Request, serviceHash hash.Ha
 	inst.Hash = hash.Dump(inst)
 
 	if store := request.KVStore(s.storeKey); !store.Has(inst.Hash) {
-		value, err := codec.MarshalBinaryBare(inst)
+		value, err := codec.MarshalJSON(inst)
 		if err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func (s *Backend) Get(request cosmostypes.Request, hash hash.Hash) (*instance.In
 		return nil, fmt.Errorf("instance %q not found", hash)
 	}
 	value := store.Get(hash)
-	return i, codec.UnmarshalBinaryBare(value, &i)
+	return i, codec.UnmarshalJSON(value, &i)
 }
 
 // Exists returns true if a specific set of data exists in the database, false otherwise
@@ -107,7 +107,7 @@ func (s *Backend) List(request cosmostypes.Request, f *api.ListInstanceRequest_F
 	// filter results
 	for iter.Valid() {
 		var i *instance.Instance
-		if err := codec.UnmarshalBinaryBare(iter.Value(), &i); err != nil {
+		if err := codec.UnmarshalJSON(iter.Value(), &i); err != nil {
 			return nil, err
 		}
 		if f == nil || f.ServiceHash.IsZero() || i.ServiceHash.Equal(f.ServiceHash) {

--- a/sdk/ownership/backend.go
+++ b/sdk/ownership/backend.go
@@ -60,7 +60,7 @@ func (s *Backend) Create(req cosmostypes.Request, owner cosmostypes.AccAddress, 
 	}
 	ownership.Hash = hash.Dump(ownership)
 
-	value, err := codec.MarshalBinaryBare(ownership)
+	value, err := codec.MarshalJSON(ownership)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *Backend) List(req cosmostypes.Request) ([]*ownership.Ownership, error) 
 
 	for iter.Valid() {
 		var o *ownership.Ownership
-		if err := codec.UnmarshalBinaryBare(iter.Value(), &o); err != nil {
+		if err := codec.UnmarshalJSON(iter.Value(), &o); err != nil {
 			return nil, err
 		}
 		ownerships = append(ownerships, o)
@@ -110,7 +110,7 @@ func (s *Backend) findOwnerships(store cosmostypes.KVStore, owner string, resour
 
 	for iter.Valid() {
 		var o *ownership.Ownership
-		if err := codec.UnmarshalBinaryBare(iter.Value(), &o); err == nil {
+		if err := codec.UnmarshalJSON(iter.Value(), &o); err == nil {
 			if (owner == "" || o.Owner == owner) && o.ResourceHash.Equal(resourceHash) {
 				ownerships = append(ownerships, o.Hash)
 			}

--- a/sdk/process/backend.go
+++ b/sdk/process/backend.go
@@ -99,7 +99,7 @@ func (s *Backend) Create(req cosmostypes.Request, msg *msgCreateProcess) (*proce
 		}
 	}
 
-	value, err := codec.MarshalBinaryBare(p)
+	value, err := codec.MarshalJSON(p)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (s *Backend) Get(req cosmostypes.Request, hash hash.Hash) (*process.Process
 	}
 
 	var p *process.Process
-	return p, codec.UnmarshalBinaryBare(store.Get(hash), &p)
+	return p, codec.UnmarshalJSON(store.Get(hash), &p)
 }
 
 // List returns all services.
@@ -140,7 +140,7 @@ func (s *Backend) List(req cosmostypes.Request) ([]*process.Process, error) {
 	)
 	for iter.Valid() {
 		var p *process.Process
-		if err := codec.UnmarshalBinaryBare(iter.Value(), &p); err != nil {
+		if err := codec.UnmarshalJSON(iter.Value(), &p); err != nil {
 			return nil, err
 		}
 		processes = append(processes, p)

--- a/sdk/runner/backend.go
+++ b/sdk/runner/backend.go
@@ -84,7 +84,7 @@ func (s *Backend) Create(request cosmostypes.Request, msg *msgCreateRunner) (*ru
 	if store.Has(run.Hash) {
 		return nil, fmt.Errorf("runner %q already exists", run.Hash)
 	}
-	value, err := codec.MarshalBinaryBare(run)
+	value, err := codec.MarshalJSON(run)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (s *Backend) Delete(request cosmostypes.Request, msg *msgDeleteRunner) erro
 	store := request.KVStore(s.storeKey)
 	run := runner.Runner{}
 	value := store.Get(msg.RunnerHash)
-	if err := codec.UnmarshalBinaryBare(value, &run); err != nil {
+	if err := codec.UnmarshalJSON(value, &run); err != nil {
 		return err
 	}
 	if run.Address != msg.Address.String() {
@@ -115,7 +115,7 @@ func (s *Backend) Get(request cosmostypes.Request, hash hash.Hash) (*runner.Runn
 	}
 	value := store.Get(hash)
 	var run *runner.Runner
-	return run, codec.UnmarshalBinaryBare(value, &run)
+	return run, codec.UnmarshalJSON(value, &run)
 }
 
 // List returns all runners.
@@ -127,7 +127,7 @@ func (s *Backend) List(request cosmostypes.Request) ([]*runner.Runner, error) {
 	for iter.Valid() {
 		var run *runner.Runner
 		value := iter.Value()
-		if err := codec.UnmarshalBinaryBare(value, &run); err != nil {
+		if err := codec.UnmarshalJSON(value, &run); err != nil {
 			return nil, err
 		}
 		runners = append(runners, run)

--- a/sdk/service/backend.go
+++ b/sdk/service/backend.go
@@ -64,7 +64,7 @@ func (s *Backend) querier(request cosmostypes.Request, path []string, req abci.R
 		return s.List(request)
 	case "hash":
 		var createServiceRequest api.CreateServiceRequest
-		if err := codec.UnmarshalBinaryBare(req.Data, &createServiceRequest); err != nil {
+		if err := codec.UnmarshalJSON(req.Data, &createServiceRequest); err != nil {
 			return nil, err
 		}
 		return s.Hash(&createServiceRequest), nil
@@ -105,7 +105,7 @@ func (s *Backend) Create(request cosmostypes.Request, msg *msgCreateService) (*s
 		return nil, err
 	}
 
-	value, err := codec.MarshalBinaryBare(srv)
+	value, err := codec.MarshalJSON(srv)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (s *Backend) Get(request cosmostypes.Request, hash hash.Hash) (*service.Ser
 		return nil, fmt.Errorf("service %q not found", hash)
 	}
 	value := store.Get(hash)
-	return sv, codec.UnmarshalBinaryBare(value, &sv)
+	return sv, codec.UnmarshalJSON(value, &sv)
 }
 
 // Exists returns true if a specific set of data exists in the database, false otherwise
@@ -142,7 +142,7 @@ func (s *Backend) List(request cosmostypes.Request) ([]*service.Service, error) 
 	)
 	for iter.Valid() {
 		var sv *service.Service
-		if err := codec.UnmarshalBinaryBare(iter.Value(), &sv); err != nil {
+		if err := codec.UnmarshalJSON(iter.Value(), &sv); err != nil {
 			return nil, err
 		}
 		services = append(services, sv)


### PR DESCRIPTION
By changing encoding to json we make tendermint compatible from any client.
With that the CLI or any UI can interact directly with tendermint without interacting with any engine's api

