### PR TITLE
Emit only one event with multiple attributes in cosmos module handler

### DIFF
--- a/cosmos/module.go
+++ b/cosmos/module.go
@@ -114,17 +114,17 @@ func (m *AppModule) NewHandler() cosmostypes.Handler {
 			return cosmostypes.ErrInternal(err.Error()).Result()
 		}
 
-		request.EventManager().EmitEvent(cosmostypes.NewEvent(
+		event := cosmostypes.NewEvent(
 			cosmostypes.EventTypeMessage,
 			cosmostypes.NewAttribute(cosmostypes.AttributeKeyModule, m.name),
-		))
-
+		)
 		if hash != nil {
-			request.EventManager().EmitEvent(cosmostypes.NewEvent(
-				cosmostypes.EventTypeMessage,
+			event = event.AppendAttributes(
 				cosmostypes.NewAttribute(AttributeKeyHash, hash.String()),
-			))
+			)
 		}
+		request.EventManager().EmitEvent(event)
+
 		return cosmostypes.Result{
 			Data:   hash,
 			Events: request.EventManager().Events(),


### PR DESCRIPTION
Fixes https://github.com/mesg-foundation/engine/issues/1624

New event output:
```json
[ { "key": "module", "value": "runner" }, { "key": "hash", "value": "9CxqDUrJaXj8Vea6kL5dMzyn7sD6nx6htePkbLitNxfq" } ]
```

<img width="997" alt="Screen Shot 2020-01-31 at 15 11 08" src="https://user-images.githubusercontent.com/5823445/73522786-eab96800-443b-11ea-9fd6-1795cbc1296b.png">

----

Should we also create a new type of event. Currently we are using "message" that is define by cosmos.
