### PR TITLE
Improve LCD server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,7 @@ func defaultConfig() (*Config, error) {
 	c.Tendermint.Config.Consensus.TimeoutCommit = 5 * time.Second
 	c.Tendermint.Config.Instrumentation.Prometheus = true
 	c.Tendermint.Config.Instrumentation.PrometheusListenAddr = "0.0.0.0:26660"
+	c.Tendermint.Config.TxIndex.IndexAllTags = true
 
 	c.Cosmos.RelativePath = "cosmos"
 	c.Cosmos.MinGasPrices = "1.0atto"

--- a/core/main.go
+++ b/core/main.go
@@ -224,7 +224,10 @@ func main() {
 		logrus.WithField("module", "main").Fatalln(err)
 	}
 
-	cliCtx := context.NewCLIContext().WithCodec(codec.Codec).WithClient(client)
+	cliCtx := context.NewCLIContext().
+		WithCodec(codec.Codec).
+		WithClient(client).
+		WithTrustNode(true)
 	mux := mux.NewRouter()
 	cosmosclient.RegisterRoutes(cliCtx, mux)
 	authrest.RegisterTxRoutes(cliCtx, mux)


### PR DESCRIPTION
In order to use the LCD server at its full potential, I did a few fixes.

### Trusted node
Configure it with a trusted node. If not we need to implement a [`Verifier`](https://pkg.go.dev/github.com/tendermint/tendermint/lite?tab=doc) but this package will be deprecated. Also, we are running a local node that runs in the same process so it is totally fine to trust it.

**Benefits:** We can now use the `/blocks/{{height}}` endpoint with no crashes ;)

### Indexer
Index all the transactions in tendermint. By default, the tendermint tx indexer is indexing only the hashes of the transactions, with the `indexAllTags` it will index all the transactions based on their events eg: `message.hash=xxx`, `message.module=service`... We need to carefully think about the events now https://github.com/mesg-foundation/engine/issues/1624

**Benefits:** We can now use the `/txs` with any type of event eg: `/txs?message.module=runner&message.hash=3TPDv7qtJFWPJUqczJdndFas4rTPzvjPzM4Mzm4R9T13`