### PR TITLE
Use disable-all instead of enable-all in golangci config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,20 +26,28 @@ issues:
       text: "exported var Translator should have its own declaration"
 
 linters:
-  enable-all: true
-  disable:
-    - depguard
-    - dupl
-    - errcheck
-    - funlen
-    - gochecknoglobals
-    - gocognit
-    - goconst
-    - godox
-    - gosec
-    - interfacer
-    - lll
-    - prealloc
-    - stylecheck
-    - wsl
-    - gochecknoinits
+  disable-all: true
+  enable: 
+    - bodyclose
+    - deadcode
+    - dogsled
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosimple
+    - govet
+    - ineffassign
+    - maligned
+    - misspell
+    - nakedret
+    - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace


### PR DESCRIPTION
Small PR that switch enable-all in favor of disable-all.

- enable-all has been declared as bad practice
- vim plugin doesn't support enable-all anymore.