### PR TITLE
send coins to resources' address

### DIFF
--- a/x/execution/internal/keeper/keeper.go
+++ b/x/execution/internal/keeper/keeper.go
@@ -179,6 +179,9 @@ func (k *Keeper) distributePriceShares(ctx sdk.Context, execAddress, runnerAddre
 	if err != nil {
 		return fmt.Errorf("cannot parse coins: %w", err)
 	}
+	if coins.Empty() {
+		return nil
+	}
 
 	runnerCoins, _ := sdk.NewDecCoinsFromCoins(coins...).MulDecTruncate(runnerShare).TruncateDecimal()
 	serviceCoins := coins.Sub(runnerCoins)

--- a/x/execution/internal/types/expected_keepers.go
+++ b/x/execution/internal/types/expected_keepers.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	"github.com/mesg-foundation/engine/hash"
 	instancepb "github.com/mesg-foundation/engine/instance"
@@ -22,6 +23,7 @@ type ParamSubspace interface {
 // BankKeeper module interface.
 type BankKeeper interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
+	InputOutputCoins(ctx sdk.Context, inputs []bank.Input, outputs []bank.Output) error
 }
 
 // ServiceKeeper module interface.


### PR DESCRIPTION
Should be merged to https://github.com/mesg-foundation/engine/pull/1670

- send coins to resources' address instead of directly the resources' owner
- use the function `bankKeeper.InputOutputCoins` that verify that the total inputs is equal to the total outputs