### PR TITLE
Fix Tendermint graceful stop

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -7,7 +7,6 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
-	tmos "github.com/tendermint/tendermint/libs/os"
 	dbm "github.com/tendermint/tm-db"
 
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
@@ -136,7 +135,7 @@ var _ simapp.App = (*NewApp)(nil)
 func NewInitApp(
 	logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 	invCheckPeriod uint, baseAppOptions ...func(*bam.BaseApp),
-) *NewApp {
+) (*NewApp, error) {
 	// First define the top level codec that will be shared by the different modules
 	cdc := MakeCodec()
 
@@ -334,13 +333,12 @@ func NewInitApp(
 	app.MountTransientStores(tKeys)
 
 	if loadLatest {
-		err := app.LoadLatestVersion(app.keys[bam.MainStoreKey])
-		if err != nil {
-			tmos.Exit(err.Error())
+		if err := app.LoadLatestVersion(app.keys[bam.MainStoreKey]); err != nil {
+			return nil, err
 		}
 	}
 
-	return app
+	return app, nil
 }
 
 // GenesisState represents chain state at the start of the chain. Any initial state (account balances) are stored here.

--- a/core/main.go
+++ b/core/main.go
@@ -145,7 +145,10 @@ func main() {
 		logrus.WithField("module", "main").Fatalln(err)
 	}
 
-	initApp := app.NewInitApp(tendermintLogger, db, nil, true, 0, bam.SetMinGasPrices(cfg.Cosmos.MinGasPrices))
+	initApp, err := app.NewInitApp(tendermintLogger, db, nil, true, 0, bam.SetMinGasPrices(cfg.Cosmos.MinGasPrices))
+	if err != nil {
+		logrus.WithField("module", "main").Fatalln(err)
+	}
 	cdc := initApp.Codec()
 
 	// init key manager

--- a/core/main.go
+++ b/core/main.go
@@ -172,6 +172,14 @@ func main() {
 	if err != nil {
 		logrus.WithField("module", "main").Fatalln(err)
 	}
+	defer func() {
+		logrus.WithField("module", "main").Info("stopping tendermint")
+		if node.IsRunning() {
+			if err := node.Stop(); err != nil {
+				logrus.WithField("module", "main").Errorln(err)
+			}
+		}
+	}()
 
 	// create cosmos client
 	client, err := cosmos.NewClient(node, cdc, kb, genesis.ChainID, cfg.Account.Name, cfg.Account.Password, cfg.Cosmos.MinGasPrices)
@@ -196,6 +204,10 @@ func main() {
 	// init gRPC server.
 	server := grpc.New(mc, ep, b)
 	logrus.WithField("module", "main").Infof("starting MESG Engine version %s", version.Version)
+	defer func() {
+		logrus.WithField("module", "main").Info("stopping grpc server")
+		server.Close()
+	}()
 
 	go func() {
 		if err := server.Serve(cfg.Server.Address); err != nil {
@@ -204,14 +216,18 @@ func main() {
 	}()
 
 	logrus.WithField("module", "main").Info("starting process engine")
-	s := orchestrator.New(mc, ep)
+	orch := orchestrator.New(mc, ep)
+	defer func() {
+		logrus.WithField("module", "main").Info("stopping orchestrator")
+		orch.Stop()
+	}()
 	go func() {
-		if err := s.Start(); err != nil {
+		if err := orch.Start(); err != nil {
 			logrus.WithField("module", "main").Fatalln(err)
 		}
 	}()
 	go func() {
-		for err := range s.ErrC {
+		for err := range orch.ErrC {
 			logrus.WithField("module", "orchestrator").Warn(err)
 		}
 	}()
@@ -222,6 +238,12 @@ func main() {
 	if err != nil {
 		logrus.WithField("module", "main").Fatalln(err)
 	}
+	defer func() {
+		logrus.WithField("module", "main").Info("stopping lcd server")
+		if err := lcdServer.Close(); err != nil {
+			logrus.WithField("module", "main").Errorln(err)
+		}
+	}()
 
 	cliCtx := context.NewCLIContext().
 		WithCodec(cdc).
@@ -239,23 +261,13 @@ func main() {
 
 	<-xsignal.WaitForInterrupt()
 
-	logrus.WithField("module", "main").Info("stopping lcd server")
-	if err := lcdServer.Close(); err != nil {
-		logrus.WithField("module", "main").Fatalln(err)
-	}
-
 	logrus.WithField("module", "main").Info("stopping running services")
 	if err := stopRunningServices(mc, b, acc.GetAddress().String()); err != nil {
-		logrus.WithField("module", "main").Fatalln(err)
+		logrus.WithField("module", "main").Errorln(err)
 	}
 
 	logrus.WithField("module", "main").Info("cleanup container")
 	if err := container.Cleanup(); err != nil {
-		logrus.WithField("module", "main").Fatalln(err)
+		logrus.WithField("module", "main").Errorln(err)
 	}
-
-	logrus.WithField("module", "main").Info("stopping grpc server")
-	server.Close()
-
-	logrus.WithField("module", "main").Info("everything is stopped")
 }

--- a/core/main.go
+++ b/core/main.go
@@ -116,6 +116,7 @@ func loadOrGenDevGenesis(cdc *codec.Codec, kb *cosmos.Keybase, cfg *config.Confi
 	return cosmos.GenGenesis(cdc, kb, app.NewDefaultGenesisState(), cfg.DevGenesis.ChainID, cfg.DevGenesis.InitialBalances, cfg.DevGenesis.ValidatorDelegationCoin, cfg.Tendermint.Config.GenesisFile(), []cosmos.GenesisValidator{validator})
 }
 
+//nolint:gocyclo
 func main() {
 	xrand.SeedInit()
 

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -20,10 +20,10 @@ import (
 // New creates a new Process instance
 func New(mc *cosmos.ModuleClient, ep *publisher.EventPublisher) *Orchestrator {
 	return &Orchestrator{
-		mc:   mc,
-		ep:   ep,
-		ErrC: make(chan error),
-		stopC:     make(chan bool),
+		mc:    mc,
+		ep:    ep,
+		ErrC:  make(chan error),
+		stopC: make(chan bool),
 	}
 }
 

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -23,6 +23,7 @@ func New(mc *cosmos.ModuleClient, ep *publisher.EventPublisher) *Orchestrator {
 		mc:   mc,
 		ep:   ep,
 		ErrC: make(chan error),
+		stopC:     make(chan bool),
 	}
 }
 
@@ -55,8 +56,15 @@ func (s *Orchestrator) Start() error {
 			go s.execute(s.dependencyFilter(execution), execution, nil, execution.Outputs)
 		case err := <-errC:
 			s.ErrC <- err
+		case <-s.stopC:
+			return nil
 		}
 	}
+}
+
+// Stop stops the orchestrator engine
+func (s *Orchestrator) Stop() {
+	s.stopC <- true
 }
 
 func (s *Orchestrator) eventFilter(event *event.Event) func(wf *process.Process, node *process.Process_Node) (bool, error) {

--- a/orchestrator/type.go
+++ b/orchestrator/type.go
@@ -15,5 +15,6 @@ type Orchestrator struct {
 	eventStream     *event.Listener
 	executionStream <-chan *execution.Execution
 
-	ErrC chan error
+	ErrC  chan error
+	stopC chan bool
 }


### PR DESCRIPTION
This PR should fix https://github.com/mesg-foundation/engine/issues/1633 and fix https://github.com/mesg-foundation/engine/issues/1457 by calling the stop function of the tendermint node and by moving most of the calls to stop function in defer function.
The defer function will be executed if the engine stops because an error is returned.

I couldn't find a way to reproduce the errors without simply killing the engine (so the stops function are never called).
Also, if your engine is even partially synchronized with a blockchain, delete the cosmos folder, start the engine and stop it, then cosmos is loading the re-building the local data (`app.LoadLatestVersion`) with a blocking function that's corrupt quite easily when the engine is stopped during this time. **this function seems to be improved in latest version of cosmos**. I made the tests on engine v0.18.1 using previous cosmos.