### PR TITLE
Add pagination system on http handler of executions/list

### DIFF
--- a/execution/sort.go
+++ b/execution/sort.go
@@ -1,0 +1,8 @@
+package execution
+
+// ByBlockHeight implements sort.Interface for []*Execution based on the block height field.
+type ByBlockHeight []*Execution
+
+func (a ByBlockHeight) Len() int           { return len(a) }
+func (a ByBlockHeight) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByBlockHeight) Less(i, j int) bool { return a[i].BlockHeight < a[j].BlockHeight }

--- a/x/execution/client/rest/query.go
+++ b/x/execution/client/rest/query.go
@@ -73,13 +73,13 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		sortedExecs := sort.Interface(execution.ByBlockHeight(execs))
+		sortFunc := sort.Interface(execution.ByBlockHeight(execs))
 		for _, tag := range tags {
 			if tag == "sort='reverse'" {
-				sortedExecs = sort.Reverse(sortedExecs)
+				sortFunc = sort.Reverse(sortFunc)
 			}
 		}
-		sort.Sort(sortedExecs)
+		sort.Sort(sortFunc)
 
 		start, end := client.Paginate(len(execs), page, limit, limit)
 		if start < 0 || end < 0 {

--- a/x/execution/client/rest/query.go
+++ b/x/execution/client/rest/query.go
@@ -53,7 +53,7 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		tags, page, limit, err := rest.ParseHTTPArgs(r)
+		_, page, limit, err := rest.ParseHTTPArgs(r)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -73,17 +73,11 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		sortFunc := sort.Interface(execution.ByBlockHeight(execs))
-		for _, tag := range tags {
-			if tag == "sort='reverse'" {
-				sortFunc = sort.Reverse(sortFunc)
-			}
-		}
-		sort.Sort(sortFunc)
+		sort.Sort(sort.Reverse(execution.ByBlockHeight(execs)))
 
 		start, end := client.Paginate(len(execs), page, limit, limit)
 		if start < 0 || end < 0 {
-			execs = make([]*execution.Execution, 0)
+			execs = []*execution.Execution{}
 		} else {
 			execs = execs[start:end]
 		}


### PR DESCRIPTION
Added a simple and not optimized pagination system on `executions/list` HTTP endpoint so the explorer can fetch executions without breaking.

The parameters `page`, `limit` and `sort=reverse` can be passed to the endpoint to return different executions:

```
curl 'localhost:1317/execution/list?page=12&limit=1&sort=reverse'
```

The sort is based on the execution's blockHeight

Related to https://github.com/mesg-foundation/engine/issues/1679


--- 

Improvements that can be done now or later:
1. Move the pagination and sort system in the module's querier but need to pass as parameters page, limit and sort.
2. Move the pagination and sort system in the module's keeper and use [`KVStorePrefixIteratorPaginated`](https://github.com/cosmos/cosmos-sdk/blob/master/store/types/iterator.go) but need to pass as parameters page, limit and find a way to sort the data without iterate on all of them (index?)