### PR TITLE
Add min price for execution

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -182,6 +182,7 @@ func NewInitApp(
 	app.subspaces[staking.ModuleName] = app.paramsKeeper.Subspace(staking.DefaultParamspace)
 	app.subspaces[distr.ModuleName] = app.paramsKeeper.Subspace(distr.DefaultParamspace)
 	app.subspaces[slashing.ModuleName] = app.paramsKeeper.Subspace(slashing.DefaultParamspace)
+	app.subspaces[execution.ModuleName] = app.paramsKeeper.Subspace(execution.DefaultParamspace)
 
 	// The AccountKeeper handles address -> account lookups
 	app.accountKeeper = auth.NewAccountKeeper(
@@ -246,7 +247,16 @@ func NewInitApp(
 	app.processKeeper = process.NewKeeper(app.cdc, keys[process.StoreKey], app.instanceKeeper, app.ownershipKeeper)
 	app.serviceKeeper = service.NewKeeper(app.cdc, keys[service.StoreKey], app.ownershipKeeper)
 	app.runnerKeeper = runner.NewKeeper(app.cdc, keys[runner.StoreKey], app.instanceKeeper)
-	app.executionKeeper = execution.NewKeeper(app.cdc, keys[execution.StoreKey], app.bankKeeper, app.serviceKeeper, app.instanceKeeper, app.runnerKeeper, app.processKeeper)
+	app.executionKeeper = execution.NewKeeper(
+		app.cdc,
+		keys[execution.StoreKey],
+		app.bankKeeper,
+		app.serviceKeeper,
+		app.instanceKeeper,
+		app.runnerKeeper,
+		app.processKeeper,
+		app.subspaces[execution.ModuleName],
+	)
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,8 @@ type Config struct {
 
 	IpfsEndpoint string `validate:"required"`
 
+	DefaultExecutionPrice string `validate:"required"`
+
 	Server struct {
 		Address string `validate:"required"`
 	}
@@ -94,6 +96,8 @@ func defaultConfig() (*Config, error) {
 	c.Path = filepath.Join(home, ".mesg")
 
 	c.IpfsEndpoint = "http://ipfs.app.mesg.com:8080/ipfs/"
+
+	c.DefaultExecutionPrice = "10000atto" // /x/execution/internal/type/params.go#DefaultMinPrice
 
 	c.Server.Address = ":50052"
 	c.Log.Format = "text"

--- a/core/main.go
+++ b/core/main.go
@@ -206,7 +206,7 @@ func main() {
 	}
 
 	// init gRPC server.
-	server := grpc.New(mc, ep, b)
+	server := grpc.New(mc, ep, b, cfg.DefaultExecutionPrice)
 	logrus.WithField("module", "main").Infof("starting MESG Engine version %s", version.Version)
 	defer func() {
 		logrus.WithField("module", "main").Info("stopping grpc server")

--- a/core/main.go
+++ b/core/main.go
@@ -220,7 +220,7 @@ func main() {
 	}()
 
 	logrus.WithField("module", "main").Info("starting process engine")
-	orch := orchestrator.New(mc, ep)
+	orch := orchestrator.New(mc, ep, cfg.DefaultExecutionPrice)
 	defer func() {
 		logrus.WithField("module", "main").Info("stopping orchestrator")
 		orch.Stop()

--- a/e2e/execution_test.go
+++ b/e2e/execution_test.go
@@ -207,7 +207,7 @@ func testExecution(t *testing.T) {
 			TaskKey:      "task1",
 			EventHash:    hash.Int(1),
 			ExecutorHash: executorHash,
-			Price:        "50atto",
+			Price:        "50000atto",
 			Inputs:       inputs,
 		})
 		require.NoError(t, err)
@@ -217,7 +217,7 @@ func testExecution(t *testing.T) {
 			coins := sdk.Coins{}
 			execAddress := sdk.AccAddress(crypto.AddressHash(resp.Hash))
 			lcdGet(t, "bank/balances/"+execAddress.String(), &coins)
-			require.True(t, coins.AmountOf("atto").Equal(sdk.NewInt(50)))
+			require.True(t, coins.AmountOf("atto").Equal(sdk.NewInt(50000)))
 		})
 
 		_, err = streamInProgress.Recv()
@@ -232,14 +232,14 @@ func testExecution(t *testing.T) {
 			coins := sdk.Coins{}
 			executorAddress := sdk.AccAddress(crypto.AddressHash(executorHash))
 			lcdGet(t, "bank/balances/"+executorAddress.String(), &coins)
-			require.True(t, coins.AmountOf("atto").Equal(sdk.NewInt(45)))
+			require.True(t, coins.AmountOf("atto").Equal(sdk.NewInt(45000)))
 		})
 		// check balance of service
 		t.Run("service balance", func(t *testing.T) {
 			coins := sdk.Coins{}
 			serviceAddress := sdk.AccAddress(crypto.AddressHash(testServiceHash))
 			lcdGet(t, "bank/balances/"+serviceAddress.String(), &coins)
-			require.True(t, coins.AmountOf("atto").Equal(sdk.NewInt(5)))
+			require.True(t, coins.AmountOf("atto").Equal(sdk.NewInt(5000)))
 		})
 		// check balance of execution
 		t.Run("execution balance", func(t *testing.T) {

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -18,12 +18,13 @@ import (
 )
 
 // New creates a new Process instance
-func New(mc *cosmos.ModuleClient, ep *publisher.EventPublisher) *Orchestrator {
+func New(mc *cosmos.ModuleClient, ep *publisher.EventPublisher, execPrice string) *Orchestrator {
 	return &Orchestrator{
-		mc:    mc,
-		ep:    ep,
-		ErrC:  make(chan error),
-		stopC: make(chan bool),
+		mc:        mc,
+		ep:        ep,
+		ErrC:      make(chan error),
+		stopC:     make(chan bool),
+		execPrice: execPrice,
 	}
 }
 
@@ -273,6 +274,7 @@ func (s *Orchestrator) processTask(nodeKey string, task *process.Process_Node_Ta
 		TaskKey:      task.TaskKey,
 		Inputs:       data,
 		ExecutorHash: executor.Hash,
+		Price:        s.execPrice,
 		Tags:         nil,
 	})
 	return err

--- a/orchestrator/type.go
+++ b/orchestrator/type.go
@@ -17,4 +17,6 @@ type Orchestrator struct {
 
 	ErrC  chan error
 	stopC chan bool
+
+	execPrice string
 }

--- a/server/grpc/api/execution.go
+++ b/server/grpc/api/execution.go
@@ -11,16 +11,20 @@ import (
 
 // ExecutionServer serve execution functions.
 type ExecutionServer struct {
-	mc *cosmos.ModuleClient
+	mc        *cosmos.ModuleClient
+	execPrice string
 }
 
 // NewExecutionServer creates a new ExecutionServer.
-func NewExecutionServer(mc *cosmos.ModuleClient) *ExecutionServer {
-	return &ExecutionServer{mc: mc}
+func NewExecutionServer(mc *cosmos.ModuleClient, execPrice string) *ExecutionServer {
+	return &ExecutionServer{mc: mc, execPrice: execPrice}
 }
 
 // Create creates an execution.
 func (s *ExecutionServer) Create(ctx context.Context, req *api.CreateExecutionRequest) (*api.CreateExecutionResponse, error) {
+	if req.Price == "" {
+		req.Price = s.execPrice
+	}
 	exec, err := s.mc.CreateExecution(req)
 	if err != nil {
 		return nil, err

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -22,18 +22,20 @@ import (
 
 // Server contains the server config.
 type Server struct {
-	instance *grpc.Server
-	mc       *cosmos.ModuleClient
-	ep       *publisher.EventPublisher
-	b        *builder.Builder
+	instance  *grpc.Server
+	mc        *cosmos.ModuleClient
+	ep        *publisher.EventPublisher
+	b         *builder.Builder
+	execPrice string
 }
 
 // New returns a new gRPC server.
-func New(mc *cosmos.ModuleClient, ep *publisher.EventPublisher, b *builder.Builder) *Server {
+func New(mc *cosmos.ModuleClient, ep *publisher.EventPublisher, b *builder.Builder, execPrice string) *Server {
 	return &Server{
-		mc: mc,
-		ep: ep,
-		b:  b,
+		mc:        mc,
+		ep:        ep,
+		b:         b,
+		execPrice: execPrice,
 	}
 }
 
@@ -82,7 +84,7 @@ func validateInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryS
 // register all server
 func (s *Server) register() {
 	protobuf_api.RegisterEventServer(s.instance, api.NewEventServer(s.ep))
-	protobuf_api.RegisterExecutionServer(s.instance, api.NewExecutionServer(s.mc))
+	protobuf_api.RegisterExecutionServer(s.instance, api.NewExecutionServer(s.mc, s.execPrice))
 	protobuf_api.RegisterInstanceServer(s.instance, api.NewInstanceServer(s.mc))
 	protobuf_api.RegisterServiceServer(s.instance, api.NewServiceServer(s.mc))
 	protobuf_api.RegisterProcessServer(s.instance, api.NewProcessServer(s.mc))

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestServerServe(t *testing.T) {
-	s := New(nil, nil, nil)
+	s := New(nil, nil, nil, "10000atto")
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 		s.Close()

--- a/x/execution/genesis.go
+++ b/x/execution/genesis.go
@@ -9,6 +9,7 @@ import (
 // InitGenesis initialize default parameters
 // and the keeper's address to pubkey map
 func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.ValidatorUpdate {
+	k.SetParams(ctx, data.Params)
 	return []abci.ValidatorUpdate{}
 }
 
@@ -16,5 +17,6 @@ func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.Vali
 // to a genesis file, which can be imported again
 // with InitGenesis
 func ExportGenesis(ctx sdk.Context, k Keeper) (data types.GenesisState) {
-	return types.NewGenesisState()
+	params := k.GetParams(ctx)
+	return types.NewGenesisState(params)
 }

--- a/x/execution/internal/keeper/keeper.go
+++ b/x/execution/internal/keeper/keeper.go
@@ -59,6 +59,12 @@ func (k *Keeper) Create(ctx sdk.Context, msg types.MsgCreateExecution) (*executi
 	if err != nil {
 		return nil, err
 	}
+
+	minPrice := k.MinPrice(ctx)
+	if !price.IsAllGTE(minPrice) {
+		return nil, fmt.Errorf("execution price too low. Min value: %q", minPrice)
+	}
+
 	run, err := k.runnerKeeper.Get(ctx, msg.Request.ExecutorHash)
 	if err != nil {
 		return nil, err

--- a/x/execution/internal/keeper/keeper.go
+++ b/x/execution/internal/keeper/keeper.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/x/params"
 	executionpb "github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/protobuf/api"
@@ -30,10 +31,11 @@ type Keeper struct {
 	instanceKeeper types.InstanceKeeper
 	runnerKeeper   types.RunnerKeeper
 	processKeeper  types.ProcessKeeper
+	paramstore     params.Subspace
 }
 
 // NewKeeper creates a execution keeper
-func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, bankKeeper types.BankKeeper, serviceKeeper types.ServiceKeeper, instanceKeeper types.InstanceKeeper, runnerKeeper types.RunnerKeeper, processKeeper types.ProcessKeeper) Keeper {
+func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, bankKeeper types.BankKeeper, serviceKeeper types.ServiceKeeper, instanceKeeper types.InstanceKeeper, runnerKeeper types.RunnerKeeper, processKeeper types.ProcessKeeper, paramstore params.Subspace) Keeper {
 	return Keeper{
 		storeKey:       key,
 		cdc:            cdc,
@@ -42,6 +44,7 @@ func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, bankKeeper types.BankKeeper, 
 		instanceKeeper: instanceKeeper,
 		runnerKeeper:   runnerKeeper,
 		processKeeper:  processKeeper,
+		paramstore:     paramstore.WithKeyTable(types.ParamKeyTable()),
 	}
 }
 

--- a/x/execution/internal/keeper/keeper.go
+++ b/x/execution/internal/keeper/keeper.go
@@ -60,9 +60,12 @@ func (k *Keeper) Create(ctx sdk.Context, msg types.MsgCreateExecution) (*executi
 		return nil, err
 	}
 
-	minPrice := k.MinPrice(ctx)
-	if !price.IsAllGTE(minPrice) {
-		return nil, fmt.Errorf("execution price too low. Min value: %q", minPrice)
+	minPriceCoin, err := sdk.ParseCoins(k.MinPrice(ctx))
+	if err != nil {
+		return nil, err
+	}
+	if !price.IsAllGTE(minPriceCoin) {
+		return nil, fmt.Errorf("execution price too low. Min value: %q", minPriceCoin.String())
 	}
 
 	run, err := k.runnerKeeper.Get(ctx, msg.Request.ExecutorHash)

--- a/x/execution/internal/keeper/params.go
+++ b/x/execution/internal/keeper/params.go
@@ -11,14 +11,10 @@ const (
 )
 
 // MinPrice - Minimum price of an execution
-func (k Keeper) MinPrice(ctx sdk.Context) sdk.Coins {
-	var coinstr string
-	k.paramstore.Get(ctx, types.KeyMinPrice, &coinstr)
-	price, err := sdk.ParseCoins(coinstr)
-	if err != nil {
-		panic(err)
-	}
-	return price
+func (k Keeper) MinPrice(ctx sdk.Context) string {
+	var coins string
+	k.paramstore.Get(ctx, types.KeyMinPrice, &coins)
+	return coins
 }
 
 // SetParams will populate all the params

--- a/x/execution/internal/keeper/params.go
+++ b/x/execution/internal/keeper/params.go
@@ -1,0 +1,34 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/mesg-foundation/engine/x/execution/internal/types"
+)
+
+// Default parameter namespace
+const (
+	DefaultParamspace = types.ModuleName
+)
+
+// MinPrice - Minimum price of an execution
+func (k Keeper) MinPrice(ctx sdk.Context) sdk.Coins {
+	var coinstr string
+	k.paramstore.Get(ctx, types.KeyMinPrice, &coinstr)
+	price, err := sdk.ParseCoins(coinstr)
+	if err != nil {
+		panic(err)
+	}
+	return price
+}
+
+// SetParams will populate all the params
+func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
+	k.paramstore.SetParamSet(ctx, &params)
+}
+
+// GetParams returns all the params of the module
+func (k Keeper) GetParams(ctx sdk.Context) types.Params {
+	var params types.Params
+	k.paramstore.GetParamSet(ctx, &params)
+	return params
+}

--- a/x/execution/internal/types/genesis.go
+++ b/x/execution/internal/types/genesis.go
@@ -1,16 +1,20 @@
 package types
 
 // GenesisState - all instance state that must be provided at genesis
-type GenesisState struct{}
+type GenesisState struct {
+	Params Params `json:"params" yaml:"params"`
+}
 
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState() GenesisState {
-	return GenesisState{}
+func NewGenesisState(params Params) GenesisState {
+	return GenesisState{Params: params}
 }
 
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
-	return GenesisState{}
+	return GenesisState{
+		Params: DefaultParams(),
+	}
 }
 
 // ValidateGenesis validates the instance genesis parameters

--- a/x/execution/internal/types/params.go
+++ b/x/execution/internal/types/params.go
@@ -21,7 +21,7 @@ var (
 
 // Params - used for initializing default parameter for instance at genesis
 type Params struct {
-	MinPrice string `json:"min_price" yaml:"min_price"` // min price to pay for an execution
+	MinPrice string `json:"minPrice" yaml:"minPrice"` // min price to pay for an execution
 }
 
 // NewParams creates a new Params object

--- a/x/execution/internal/types/params.go
+++ b/x/execution/internal/types/params.go
@@ -1,38 +1,66 @@
 package types
 
 import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/cosmos/cosmos-sdk/x/params/subspace"
 )
 
 // Default parameter namespace
 const (
 	DefaultParamspace = ModuleName
+	DefaultMinPrice   = "10000atto"
 )
 
-// ParamKeyTable for instance module
-func ParamKeyTable() params.KeyTable {
-	return params.NewKeyTable().RegisterParamSet(&Params{})
-}
+var (
+	// KeyMinPrice key for the parameter MinPrice
+	KeyMinPrice = []byte("MinPrice")
+)
 
 // Params - used for initializing default parameter for instance at genesis
-type Params struct{}
+type Params struct {
+	MinPrice string `json:"min_price" yaml:"min_price"` // min price to pay for an execution
+}
 
 // NewParams creates a new Params object
-func NewParams() Params {
-	return Params{}
+func NewParams(minPrice string) Params {
+	return Params{
+		MinPrice: minPrice,
+	}
+}
+
+// ParamKeyTable for auth module
+func ParamKeyTable() subspace.KeyTable {
+	return subspace.NewKeyTable().RegisterParamSet(&Params{})
 }
 
 // String implements the stringer interface for Params
 func (p Params) String() string {
-	return ""
+	return fmt.Sprintf(`Params:
+	MinPrice:			%s
+	`, p.MinPrice)
 }
 
 // ParamSetPairs - Implements params.ParamSet
 func (p *Params) ParamSetPairs() params.ParamSetPairs {
-	return params.ParamSetPairs{}
+	return params.ParamSetPairs{
+		params.NewParamSetPair(KeyMinPrice, &p.MinPrice, validateMinPrice),
+	}
 }
 
 // DefaultParams defines the parameters for this module
 func DefaultParams() Params {
-	return NewParams()
+	return NewParams(DefaultMinPrice)
+}
+
+func validateMinPrice(i interface{}) error {
+	v, ok := i.(string)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+
+	_, err := sdk.ParseCoins(v)
+	return err
 }

--- a/x/execution/module.go
+++ b/x/execution/module.go
@@ -116,8 +116,7 @@ func (am AppModule) NewQuerierHandler() sdk.Querier {
 func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
 	var genesisState GenesisState
 	ModuleCdc.MustUnmarshalJSON(data, &genesisState)
-	InitGenesis(ctx, am.keeper, genesisState)
-	return []abci.ValidatorUpdate{}
+	return InitGenesis(ctx, am.keeper, genesisState)
 }
 
 // ExportGenesis returns the exported genesis state as raw bytes for the execution


### PR DESCRIPTION
Right now an execution can be created with 0 tokens.

I added the support of a minimum that is set for now to `10000atto`. This parameter is part of the module and present in the genesis.
I also added a config to have a default price from the clients (api/orchestrator)

The good thing of having this parameter in the genesis is that we could do some vote to change this limit and we can play with proposal/votes.