### PR TITLE
Add transaction's log to returned error

### DIFF
--- a/cosmos/client.go
+++ b/cosmos/client.go
@@ -105,7 +105,7 @@ func (c *Client) BuildAndBroadcastMsg(msg sdktypes.Msg) (*abci.ResponseDeliverTx
 	}
 
 	if txres.Code != abci.CodeTypeOK {
-		return nil, fmt.Errorf("transaction returned with invalid code %d", txres.Code)
+		return nil, fmt.Errorf("transaction returned with invalid code %d: %s", txres.Code, txres.Log)
 	}
 
 	// TODO: 20*time.Second should not be hardcoded here
@@ -131,7 +131,7 @@ func (c *Client) BuildAndBroadcastMsg(msg sdktypes.Msg) (*abci.ResponseDeliverTx
 		}
 		return &data.TxResult.Result, nil
 	case <-ctx.Done():
-		return nil, errors.New("i/o timeout")
+		return nil, errors.New("reach timeout for listening for transaction result")
 	}
 }
 


### PR DESCRIPTION
Simple PR that adds the transaction's log that actually contains the error message to the returned error when the transaction failed.
So instead of having just the code number, we will have the corresponding error message.