### PR TITLE
Add calculate hash lcd endpoints

### DIFF
--- a/cosmos/module_client.go
+++ b/cosmos/module_client.go
@@ -70,13 +70,6 @@ func (mc *ModuleClient) ExistService(hash hash.Hash) (bool, error) {
 	return out, mc.QueryJSON(route, nil, &out)
 }
 
-// HashService returns the calculate hash of a service.
-func (mc *ModuleClient) HashService(req *api.CreateServiceRequest) (hash.Hash, error) {
-	var out hash.Hash
-	route := sroutef("%s/%s", service.QuerierRoute, service.QueryHashService)
-	return out, mc.QueryJSON(route, req, &out)
-}
-
 // CreateProcess creates a new process.
 func (mc *ModuleClient) CreateProcess(req *api.CreateProcessRequest) (*processpb.Process, error) {
 	acc, err := mc.GetAccount()

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -37,6 +37,7 @@ var (
 	cclient               *cosmos.Client
 	cdc                   = app.MakeCodec()
 	processInitialBalance = sdk.NewCoins(sdk.NewInt64Coin("atto", 10000000))
+	engineAddress         sdk.AccAddress
 )
 
 const (
@@ -96,8 +97,9 @@ func TestAPI(t *testing.T) {
 	kb, err := cosmos.NewKeybase(filepath.Join(cfg.Path, cfg.Cosmos.RelativePath))
 	require.NoError(t, err)
 	if cfg.Account.Mnemonic != "" {
-		_, err = kb.CreateAccount(cfg.Account.Name, cfg.Account.Mnemonic, "", cfg.Account.Password, keys.CreateHDPath(cfg.Account.Number, cfg.Account.Index).String(), cosmos.DefaultAlgo)
+		acc, err := kb.CreateAccount(cfg.Account.Name, cfg.Account.Mnemonic, "", cfg.Account.Password, keys.CreateHDPath(cfg.Account.Number, cfg.Account.Index).String(), cosmos.DefaultAlgo)
 		require.NoError(t, err)
+		engineAddress = acc.GetAddress()
 	}
 
 	httpclient, err := rpcclient.NewHTTP("http://localhost:26657", "/websocket")

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -49,6 +49,7 @@ func lcdGet(t *testing.T, path string, ptr interface{}) {
 	resp, err := http.Get(lcdEndpoint + path)
 	require.NoError(t, err)
 	defer resp.Body.Close()
+	require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300, "request status code is not 2XX")
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	cosResp := rest.ResponseWithHeight{}
@@ -64,6 +65,7 @@ func lcdPost(t *testing.T, path string, req interface{}, ptr interface{}) {
 	resp, err := http.Post(lcdEndpoint+path, lcdPostContentType, bytes.NewReader(reqBody))
 	require.NoError(t, err)
 	defer resp.Body.Close()
+	require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300, "request status code is not 2XX")
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	cosResp := rest.ResponseWithHeight{}

--- a/e2e/process_test.go
+++ b/e2e/process_test.go
@@ -125,6 +125,12 @@ func testProcess(t *testing.T) {
 		})
 	})
 
+	t.Run("hash", func(t *testing.T) {
+		var hash hash.Hash
+		lcdPost(t, "process/hash", req, &hash)
+		require.Equal(t, processHash, hash)
+	})
+
 	t.Run("delete", func(t *testing.T) {
 		_, err := client.ProcessClient.Delete(context.Background(), &pb.DeleteProcessRequest{Hash: processHash})
 		require.NoError(t, err)

--- a/e2e/runner_test.go
+++ b/e2e/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mesg-foundation/engine/protobuf/acknowledgement"
 	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/runner"
+	runnerrest "github.com/mesg-foundation/engine/x/runner/client/rest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,6 +81,17 @@ func testRunner(t *testing.T) {
 			require.Equal(t, testInstanceHash, rs[0].InstanceHash)
 			require.Equal(t, testRunnerHash, rs[0].Hash)
 		})
+	})
+
+	t.Run("hash", func(t *testing.T) {
+		var res runnerrest.HashResponse
+		lcdPost(t, "runner/hash", &runnerrest.HashRequest{
+			ServiceHash: testServiceHash,
+			Address:     engineAddress.String(),
+			Env:         []string{"BAR=3", "REQUIRED=4"},
+		}, &res)
+		require.Equal(t, testRunnerHash, res.RunnerHash)
+		require.Equal(t, testInstanceHash, res.InstanceHash)
 	})
 }
 

--- a/e2e/service_test.go
+++ b/e2e/service_test.go
@@ -73,16 +73,9 @@ func testService(t *testing.T) {
 	})
 
 	t.Run("hash", func(t *testing.T) {
-		t.Run("grpc", func(t *testing.T) {
-			resp, err := client.ServiceClient.Hash(context.Background(), req)
-			require.NoError(t, err)
-			require.Equal(t, testServiceHash, resp.Hash)
-		})
-		t.Run("lcd", func(t *testing.T) {
-			var hash hash.Hash
-			lcdPost(t, "service/hash", req, &hash)
-			require.Equal(t, testServiceHash, hash)
-		})
+		var hash hash.Hash
+		lcdPost(t, "service/hash", req, &hash)
+		require.Equal(t, testServiceHash, hash)
 	})
 
 	t.Run("check ownership creation", func(t *testing.T) {

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -1,0 +1,12 @@
+package instance
+
+import "github.com/mesg-foundation/engine/hash"
+
+func New(serviceHash hash.Hash, envHash hash.Hash) *Instance {
+	inst := &Instance{
+		ServiceHash: serviceHash,
+		EnvHash:     envHash,
+	}
+	inst.Hash = hash.Dump(inst)
+	return inst
+}

--- a/server/grpc/api/service.go
+++ b/server/grpc/api/service.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mesg-foundation/engine/cosmos"
 	protobuf_api "github.com/mesg-foundation/engine/protobuf/api"
@@ -53,9 +54,5 @@ func (s *ServiceServer) Exists(ctx context.Context, req *protobuf_api.ExistsServ
 
 // Hash returns the calculated hash of a service request.
 func (s *ServiceServer) Hash(ctx context.Context, req *protobuf_api.CreateServiceRequest) (*protobuf_api.HashServiceResponse, error) {
-	h, err := s.mc.HashService(req)
-	if err != nil {
-		return nil, err
-	}
-	return &protobuf_api.HashServiceResponse{Hash: h}, nil
+	return nil, fmt.Errorf("not implemented anymore, use LCD")
 }

--- a/service/service.go
+++ b/service/service.go
@@ -3,8 +3,31 @@ package service
 import (
 	"fmt"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/protobuf/types"
+	"github.com/tendermint/tendermint/crypto"
 )
+
+func New(sid, name, description string, configuration Service_Configuration, tasks []*Service_Task, events []*Service_Event, dependencies []*Service_Dependency, repository, source string) *Service {
+	// create service
+	srv := &Service{
+		Sid:           sid,
+		Name:          name,
+		Description:   description,
+		Configuration: configuration,
+		Tasks:         tasks,
+		Events:        events,
+		Dependencies:  dependencies,
+		Repository:    repository,
+		Source:        source,
+	}
+
+	// calculate and apply hash to service.
+	srv.Hash = hash.Dump(srv)
+	srv.Address = sdk.AccAddress(crypto.AddressHash(srv.Hash))
+	return srv
+}
 
 // MainServiceKey is key for main service.
 const MainServiceKey = "service"

--- a/x/execution/client/rest/query.go
+++ b/x/execution/client/rest/query.go
@@ -18,6 +18,7 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 		"/execution/get/{hash}",
 		queryGetHandlerFn(cliCtx),
 	).Methods(http.MethodGet)
+
 	r.HandleFunc(
 		"/execution/list",
 		queryListHandlerFn(cliCtx),

--- a/x/instance/client/rest/query.go
+++ b/x/instance/client/rest/query.go
@@ -15,14 +15,16 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 		"/instance/get/{hash}",
 		queryGetHandlerFn(cliCtx),
 	).Methods(http.MethodGet)
+
 	r.HandleFunc(
 		"/instance/list",
 		queryListHandlerFn(cliCtx),
 	).Methods(http.MethodGet)
+
 	r.HandleFunc(
 		"/instance/parameters",
 		queryParametersHandlerFn(cliCtx),
-	).Methods("GET")
+	).Methods(http.MethodGet)
 }
 
 func queryGetHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {

--- a/x/instance/internal/keeper/keeper.go
+++ b/x/instance/internal/keeper/keeper.go
@@ -37,11 +37,7 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) FetchOrCreate(ctx sdk.Context, serviceHash hash.Hash, envHash hash.Hash) (*instance.Instance, error) {
 	store := ctx.KVStore(k.storeKey)
 
-	inst := &instance.Instance{
-		ServiceHash: serviceHash,
-		EnvHash:     envHash,
-	}
-	inst.Hash = hash.Dump(inst)
+	inst := instance.New(serviceHash, envHash)
 
 	if !store.Has(inst.Hash) {
 		value, err := k.cdc.MarshalBinaryLengthPrefixed(inst)

--- a/x/ownership/client/rest/query.go
+++ b/x/ownership/client/rest/query.go
@@ -15,6 +15,7 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 		"/ownership/list",
 		queryListHandlerFn(cliCtx),
 	).Methods(http.MethodGet)
+
 	r.HandleFunc(
 		"/ownership/parameters",
 		queryParamsHandlerFn(cliCtx),

--- a/x/process/client/rest/query.go
+++ b/x/process/client/rest/query.go
@@ -2,11 +2,14 @@ package rest
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
+	"github.com/mesg-foundation/engine/process"
+	"github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/x/process/internal/types"
 )
 
@@ -15,15 +18,21 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 		"/process/get/{hash}",
 		queryGetHandlerFn(cliCtx),
 	).Methods(http.MethodGet)
+
 	r.HandleFunc(
 		"/process/list",
 		queryListHandlerFn(cliCtx),
 	).Methods(http.MethodGet)
 
 	r.HandleFunc(
+		"/process/hash",
+		queryHashHandlerFn(cliCtx),
+	).Methods(http.MethodPost)
+
+	r.HandleFunc(
 		"/process/parameters",
 		queryParamsHandlerFn(cliCtx),
-	).Methods("GET")
+	).Methods(http.MethodGet)
 }
 
 func queryGetHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
@@ -85,5 +94,30 @@ func queryParamsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 
 		cliCtx = cliCtx.WithHeight(height)
 		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+func queryHashHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		var req api.CreateProcessRequest
+		if err := cliCtx.Codec.UnmarshalJSON(data, &req); err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		proc := process.New(req.Name, req.Nodes, req.Edges)
+
+		rest.PostProcessResponse(w, cliCtx, proc.Hash.String())
 	}
 }

--- a/x/runner/client/rest/query.go
+++ b/x/runner/client/rest/query.go
@@ -2,11 +2,17 @@ package rest
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
+	"github.com/mesg-foundation/engine/ext/xos"
+	"github.com/mesg-foundation/engine/hash"
+	"github.com/mesg-foundation/engine/instance"
+	"github.com/mesg-foundation/engine/runner"
+	"github.com/mesg-foundation/engine/service"
 	"github.com/mesg-foundation/engine/x/runner/internal/types"
 )
 
@@ -15,15 +21,21 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 		"/runner/get/{hash}",
 		queryGetHandlerFn(cliCtx),
 	).Methods(http.MethodGet)
+
 	r.HandleFunc(
 		"/runner/list",
 		queryListHandlerFn(cliCtx),
 	).Methods(http.MethodGet)
 
 	r.HandleFunc(
+		"/runner/hash",
+		queryHashHandlerFn(cliCtx),
+	).Methods(http.MethodPost)
+
+	r.HandleFunc(
 		"/runner/parameters",
 		queryParamsHandlerFn(cliCtx),
-	).Methods("GET")
+	).Methods(http.MethodGet)
 }
 
 func queryGetHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
@@ -84,6 +96,64 @@ func queryParamsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		cliCtx = cliCtx.WithHeight(height)
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+// HashRequest is the request of the hash endpoint.
+type HashRequest struct {
+	ServiceHash hash.Hash `json:"serviceHash"`
+	Env         []string  `json:"env"`
+	Address     string    `json:"address"`
+}
+
+// HashResponse is the response of the hash endpoint.
+type HashResponse struct {
+	RunnerHash   hash.Hash `json:"runnerHash"`
+	InstanceHash hash.Hash `json:"instanceHash"`
+	EnvHash      hash.Hash `json:"envHash"`
+}
+
+func queryHashHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		var req HashRequest
+		if err := cliCtx.Codec.UnmarshalJSON(data, &req); err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		srvRes, _, err := cliCtx.Query("custom/service/get/" + req.ServiceHash.String())
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		var srv service.Service
+		if err := cliCtx.Codec.UnmarshalJSON(srvRes, &srv); err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		envHash := hash.Dump(xos.EnvMergeSlices(srv.Configuration.Env, req.Env))
+		inst := instance.New(req.ServiceHash, envHash)
+		run := runner.New(req.Address, inst.Hash)
+
+		res := HashResponse{
+			RunnerHash:   run.Hash,
+			InstanceHash: inst.Hash,
+			EnvHash:      envHash,
+		}
+
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }

--- a/x/service/alias.go
+++ b/x/service/alias.go
@@ -27,7 +27,6 @@ var (
 
 	QueryGetService   = types.QueryGetService
 	QueryListService  = types.QueryListService
-	QueryHashService  = types.QueryHashService
 	QueryExistService = types.QueryExistService
 
 	NewMsgCreateService = types.NewMsgCreateService

--- a/x/service/client/cli/query.go
+++ b/x/service/client/cli/query.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/service"
 	"github.com/mesg-foundation/engine/x/service/internal/types"
 	"github.com/spf13/cobra"
@@ -28,7 +27,6 @@ func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		flags.GetCommands(
 			GetCmdGetService(queryRoute, cdc),
 			GetCmdListService(queryRoute, cdc),
-			GetCmdHashService(queryRoute, cdc),
 			GetCmdExistService(queryRoute, cdc),
 		)...,
 	)
@@ -69,26 +67,6 @@ func GetCmdListService(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			}
 
 			var out []*service.Service
-			cdc.MustUnmarshalJSON(res, &out)
-			return cliCtx.PrintOutput(out)
-		},
-	}
-}
-
-func GetCmdHashService(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
-		Use:   "hash [definition]",
-		Short: "hash",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryHashService), []byte(args[0]))
-			if err != nil {
-				fmt.Printf("could not check service\n%s\n", err.Error())
-				return nil
-			}
-
-			var out hash.Hash
 			cdc.MustUnmarshalJSON(res, &out)
 			return cliCtx.PrintOutput(out)
 		},

--- a/x/service/internal/keeper/querier.go
+++ b/x/service/internal/keeper/querier.go
@@ -4,7 +4,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/mesg-foundation/engine/hash"
-	"github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/x/service/internal/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -17,8 +16,6 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return getService(ctx, k, path[1:])
 		case types.QueryListService:
 			return listService(ctx, k)
-		case types.QueryHashService:
-			return hashService(ctx, k, req)
 		case types.QueryExistService:
 			return existService(ctx, k, path[1:])
 		default:
@@ -42,21 +39,6 @@ func getService(ctx sdk.Context, k Keeper, path []string) ([]byte, error) {
 	}
 
 	res, err := types.ModuleCdc.MarshalJSON(srv)
-	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
-	}
-	return res, nil
-}
-
-func hashService(ctx sdk.Context, k Keeper, req abci.RequestQuery) ([]byte, error) {
-	var createServiceRequest api.CreateServiceRequest
-	if err := k.cdc.UnmarshalJSON(req.Data, &createServiceRequest); err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
-	}
-
-	hash := k.Hash(ctx, &createServiceRequest)
-
-	res, err := types.ModuleCdc.MarshalJSON(hash)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}

--- a/x/service/internal/types/querier.go
+++ b/x/service/internal/types/querier.go
@@ -4,6 +4,5 @@ package types
 const (
 	QueryGetService   = "get"
 	QueryListService  = "list"
-	QueryHashService  = "hash"
 	QueryExistService = "exist"
 )


### PR DESCRIPTION
closes https://github.com/mesg-foundation/engine/issues/1744

- [x] added endpoint for hash of runner (and its internal hash)
  - I created a new request and response payload to fit the special needs of this endpoint.

Endpoint: `runner/hash`
Request:
```json
{
  "serviceHash": "XXX",
  "address": "mesgtest1XXX",
  "env": [
    "FOO=bar"
  ]
}
```
Response:
```json
{
  "runnerHash": "XXX",
  "instanceHash": "XXX",
  "envHash": "XXX"
}
```

- [x] simplified the service hash endpoints by removing it from the keeper and deprecated the gRPC API
- [x] added endpoint for calculating hash of process
endpoint: `process/hash`. Request is: `protobuf/api.CreateProcessRequest` (will be changed in PR about updating cosmos messages). Response: directly the hash.