### PR TITLE
Update lcd process hash endpoint to use a dedicated request structure

### DIFF
--- a/e2e/process_test.go
+++ b/e2e/process_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mesg-foundation/engine/ownership"
 	"github.com/mesg-foundation/engine/process"
 	pb "github.com/mesg-foundation/engine/protobuf/api"
+	processrest "github.com/mesg-foundation/engine/x/process/client/rest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -126,8 +127,13 @@ func testProcess(t *testing.T) {
 	})
 
 	t.Run("hash", func(t *testing.T) {
+		msg := processrest.HashRequest{
+			Name:  req.Name,
+			Nodes: req.Nodes,
+			Edges: req.Edges,
+		}
 		var hash hash.Hash
-		lcdPost(t, "process/hash", req, &hash)
+		lcdPost(t, "process/hash", msg, &hash)
 		require.Equal(t, processHash, hash)
 	})
 

--- a/e2e/service_test.go
+++ b/e2e/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mesg-foundation/engine/ownership"
 	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/service"
+	servicerest "github.com/mesg-foundation/engine/x/service/client/rest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -73,8 +74,19 @@ func testService(t *testing.T) {
 	})
 
 	t.Run("hash", func(t *testing.T) {
+		msg := servicerest.HashRequest{
+			Sid:           req.Sid,
+			Name:          req.Name,
+			Description:   req.Description,
+			Configuration: req.Configuration,
+			Tasks:         req.Tasks,
+			Events:        req.Events,
+			Dependencies:  req.Dependencies,
+			Repository:    req.Repository,
+			Source:        req.Source,
+		}
 		var hash hash.Hash
-		lcdPost(t, "service/hash", req, &hash)
+		lcdPost(t, "service/hash", msg, &hash)
 		require.Equal(t, testServiceHash, hash)
 	})
 

--- a/x/process/client/rest/query.go
+++ b/x/process/client/rest/query.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
 	"github.com/mesg-foundation/engine/process"
-	"github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/x/process/internal/types"
 )
 
@@ -97,6 +96,13 @@ func queryParamsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	}
 }
 
+// HashRequest is the request of the hash endpoint.
+type HashRequest struct {
+	Name  string                  `json:"name,omitempty"`
+	Nodes []*process.Process_Node `json:"nodes,omitempty"`
+	Edges []*process.Process_Edge `json:"edges,omitempty"`
+}
+
 func queryHashHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
@@ -110,7 +116,7 @@ func queryHashHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var req api.CreateProcessRequest
+		var req HashRequest
 		if err := cliCtx.Codec.UnmarshalJSON(data, &req); err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return


### PR DESCRIPTION
- Update lcd process hash endpoint to use a dedicated request structure
- fix e2e test with the modif of https://github.com/mesg-foundation/engine/pull/1754