### PR TITLE
Replace runner gRPC by LCD in e2e tests

### DIFF
--- a/e2e/definition_test.go
+++ b/e2e/definition_test.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"github.com/mesg-foundation/engine/service"
-	serviceModule "github.com/mesg-foundation/engine/x/service"
+	servicemodule "github.com/mesg-foundation/engine/x/service"
 )
 
-var testComplexCreateServiceMsg = &serviceModule.MsgCreate{
+var testComplexCreateServiceMsg = &servicemodule.MsgCreate{
 	Sid:  "test-complex-service",
 	Name: "test-complex-service",
 	Dependencies: []*service.Service_Dependency{
@@ -39,7 +39,7 @@ var testComplexCreateServiceMsg = &serviceModule.MsgCreate{
 	Source: "QmSuVcdic2dhS5QKQGWp66SJQUkDRqAqCHpU6Sx9uXJcdc",
 }
 
-var testCreateServiceMsg = &serviceModule.MsgCreate{
+var testCreateServiceMsg = &servicemodule.MsgCreate{
 	Sid:  "test-service",
 	Name: "test-service",
 	Configuration: service.Service_Configuration{

--- a/e2e/runner_test.go
+++ b/e2e/runner_test.go
@@ -5,19 +5,51 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/mesg-foundation/engine/ext/xos"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/protobuf/acknowledgement"
 	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/runner"
+	"github.com/mesg-foundation/engine/runner/builder"
+	runnermodule "github.com/mesg-foundation/engine/x/runner"
 	runnerrest "github.com/mesg-foundation/engine/x/runner/client/rest"
 	"github.com/stretchr/testify/require"
 )
 
-var testRunnerHash hash.Hash
-var testRunnerAddress sdk.AccAddress
+var (
+	testRunnerHash       hash.Hash
+	testInstanceEnvHash  hash.Hash
+	testRunnerAddress    sdk.AccAddress
+	testServiceImageHash string
+)
 
 func testRunner(t *testing.T) {
-	t.Run("create", func(t *testing.T) {
+	var (
+		testInstanceEnv = xos.EnvMergeSlices(testServiceStruct.Configuration.Env, []string{"BAR=3", "REQUIRED=4"})
+	)
+	t.Run("hash", func(t *testing.T) {
+		var res runnerrest.HashResponse
+		lcdPost("runner/hash", &runnerrest.HashRequest{
+			ServiceHash: testServiceHash,
+			Address:     engineAddress.String(),
+			Env:         testInstanceEnv,
+		}, &res)
+		testRunnerHash = res.RunnerHash
+		testInstanceHash = res.InstanceHash
+		testInstanceEnvHash = res.EnvHash
+	})
+
+	t.Run("build service image", func(t *testing.T) {
+		var err error
+		testServiceImageHash, err = builder.Build(cont, testServiceStruct, ipfsEndpoint)
+		require.NoError(t, err)
+	})
+
+	t.Run("start", func(t *testing.T) {
+		require.NoError(t, builder.Start(cont, testServiceStruct, testInstanceHash, testRunnerHash, testServiceImageHash, testInstanceEnv, engineName, enginePort))
+	})
+
+	t.Run("register", func(t *testing.T) {
 		stream, err := client.EventClient.Stream(context.Background(), &pb.StreamEventRequest{
 			Filter: &pb.StreamEventRequest_Filter{
 				Key: "test_service_ready",
@@ -26,88 +58,49 @@ func testRunner(t *testing.T) {
 		require.NoError(t, err)
 		acknowledgement.WaitForStreamToBeReady(stream)
 
-		resp, err := client.RunnerClient.Create(context.Background(), &pb.CreateRunnerRequest{
+		msg := runnermodule.MsgCreate{
+			Owner:       engineAddress,
 			ServiceHash: testServiceHash,
-			Env:         []string{"BAR=3", "REQUIRED=4"},
-		})
-		require.NoError(t, err)
-		testRunnerHash = resp.Hash
+			EnvHash:     testInstanceEnvHash,
+		}
+		require.True(t, testRunnerHash.Equal(lcdBroadcastMsg(msg)))
 
 		// wait for service to be ready
 		_, err = stream.Recv()
 		require.NoError(t, err)
 	})
 
-	t.Run("recreate", func(t *testing.T) {
-		_, err := client.RunnerClient.Delete(context.Background(), &pb.DeleteRunnerRequest{Hash: testRunnerHash})
-		require.NoError(t, err)
-		resp, err := client.RunnerClient.Create(context.Background(), &pb.CreateRunnerRequest{
-			ServiceHash: testServiceHash,
-			Env:         []string{"BAR=3", "REQUIRED=4"},
-		})
-		require.NoError(t, err)
-		testRunnerHash = resp.Hash
-	})
-
 	t.Run("get", func(t *testing.T) {
-		t.Run("grpc", func(t *testing.T) {
-			resp, err := client.RunnerClient.Get(context.Background(), &pb.GetRunnerRequest{Hash: testRunnerHash})
-			require.NoError(t, err)
-			require.Equal(t, testRunnerHash, resp.Hash)
-			testInstanceHash = resp.InstanceHash
-		})
-		t.Run("lcd", func(t *testing.T) {
-			var r *runner.Runner
-			lcdGet("runner/get/"+testRunnerHash.String(), &r)
-			require.Equal(t, testRunnerHash, r.Hash)
-			testRunnerAddress = r.Address
-		})
+		var run *runner.Runner
+		lcdGet("runner/get/"+testRunnerHash.String(), &run)
+		require.Equal(t, testRunnerHash, run.Hash)
+		testRunnerAddress = run.Address
 	})
 
-	// TODO: need to test the filters
 	t.Run("list", func(t *testing.T) {
-		t.Run("grpc", func(t *testing.T) {
-			resp, err := client.RunnerClient.List(context.Background(), &pb.ListRunnerRequest{})
-			require.NoError(t, err)
-			require.Len(t, resp.Runners, 1)
-			require.Equal(t, testInstanceHash, resp.Runners[0].InstanceHash)
-			require.Equal(t, testRunnerHash, resp.Runners[0].Hash)
-		})
-		t.Run("lcd", func(t *testing.T) {
-			rs := make([]*runner.Runner, 0)
-			lcdGet("runner/list", &rs)
-			require.Len(t, rs, 1)
-			require.Equal(t, testInstanceHash, rs[0].InstanceHash)
-			require.Equal(t, testRunnerHash, rs[0].Hash)
-		})
-	})
-
-	t.Run("hash", func(t *testing.T) {
-		var res runnerrest.HashResponse
-		lcdPost("runner/hash", &runnerrest.HashRequest{
-			ServiceHash: testServiceHash,
-			Address:     engineAddress.String(),
-			Env:         []string{"BAR=3", "REQUIRED=4"},
-		}, &res)
-		require.Equal(t, testRunnerHash, res.RunnerHash)
-		require.Equal(t, testInstanceHash, res.InstanceHash)
+		rs := make([]*runner.Runner, 0)
+		lcdGet("runner/list", &rs)
+		require.Len(t, rs, 1)
+		require.Equal(t, testInstanceHash, rs[0].InstanceHash)
+		require.Equal(t, testRunnerHash, rs[0].Hash)
 	})
 }
 
 func testDeleteRunner(t *testing.T) {
-	_, err := client.RunnerClient.Delete(context.Background(), &pb.DeleteRunnerRequest{Hash: testRunnerHash})
-	require.NoError(t, err)
+	msg := runnermodule.MsgDelete{
+		Owner: engineAddress,
+		Hash:  testRunnerHash,
+	}
+	lcdBroadcastMsg(msg)
 
-	t.Run("grpc", func(t *testing.T) {
-		resp, err := client.RunnerClient.List(context.Background(), &pb.ListRunnerRequest{})
-		require.NoError(t, err)
-		require.Len(t, resp.Runners, 0)
-	})
-	t.Run("lcd", func(t *testing.T) {
+	require.NoError(t, builder.Stop(cont, testRunnerHash, testServiceStruct.Dependencies))
+
+	t.Run("check deletion", func(t *testing.T) {
 		rs := make([]*runner.Runner, 0)
 		lcdGet("runner/list", &rs)
 		require.Len(t, rs, 0)
 	})
+
 	t.Run("check coins on runner", func(t *testing.T) {
 		var coins sdk.Coins
 		lcdGet("bank/balances/"+testRunnerAddress.String(), &coins)

--- a/e2e/service_test.go
+++ b/e2e/service_test.go
@@ -14,6 +14,7 @@ import (
 var (
 	testServiceHash    hash.Hash
 	testServiceAddress sdk.AccAddress
+	testServiceStruct  *service.Service
 )
 
 func testService(t *testing.T) {
@@ -23,10 +24,9 @@ func testService(t *testing.T) {
 	})
 
 	t.Run("get", func(t *testing.T) {
-		var s *service.Service
-		lcdGet("service/get/"+testServiceHash.String(), &s)
-		require.Equal(t, testServiceHash, s.Hash)
-		testServiceAddress = s.Address
+		lcdGet("service/get/"+testServiceHash.String(), &testServiceStruct)
+		require.Equal(t, testServiceHash, testServiceStruct.Hash)
+		testServiceAddress = testServiceStruct.Address
 	})
 
 	t.Run("list", func(t *testing.T) {

--- a/runner/builder/builder.go
+++ b/runner/builder/builder.go
@@ -64,23 +64,22 @@ func (b *Builder) Create(req *api.CreateRunnerRequest) (*runnerpb.Runner, error)
 	}
 
 	// start the container
-	imageHash, err := build(b.container, srv, b.ipfsEndpoint)
+	imageHash, err := Build(b.container, srv, b.ipfsEndpoint)
 	if err != nil {
 		return nil, err
 	}
-	_, err = start(b.container, srv, inst.Hash, expRunnerHash, imageHash, instanceEnv, b.engineName, b.port)
-	if err != nil {
+	if err = Start(b.container, srv, inst.Hash, expRunnerHash, imageHash, instanceEnv, b.engineName, b.port); err != nil {
 		return nil, err
 	}
 
 	run, err := b.mc.CreateRunner(req)
 	if err != nil {
-		stop(b.container, expRunnerHash, srv.Dependencies)
+		Stop(b.container, expRunnerHash, srv.Dependencies)
 		return nil, err
 	}
 
 	if !run.Hash.Equal(expRunnerHash) {
-		stop(b.container, expRunnerHash, srv.Dependencies)
+		Stop(b.container, expRunnerHash, srv.Dependencies)
 		return nil, errors.New("calculated runner hash is not the same")
 	}
 	return run, nil
@@ -109,7 +108,7 @@ func (b *Builder) Delete(req *api.DeleteRunnerRequest) error {
 	}
 
 	// stop the local running service
-	if err := stop(b.container, r.Hash, srv.Dependencies); err != nil {
+	if err := Stop(b.container, r.Hash, srv.Dependencies); err != nil {
 		return err
 	}
 

--- a/runner/builder/container.go
+++ b/runner/builder/container.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/mesg-foundation/engine/container"
 	"github.com/mesg-foundation/engine/ext/xerrors"
 	"github.com/mesg-foundation/engine/ext/xos"
@@ -37,7 +38,10 @@ func build(cont container.Container, srv *service.Service, ipfsEndpoint string) 
 	}
 	defer resp.Body.Close()
 
-	if err := archive.Untar(resp.Body, path, nil); err != nil {
+	if err := archive.Untar(resp.Body, path, &archive.TarOptions{ChownOpts: &idtools.Identity{
+		UID: os.Geteuid(),
+		GID: os.Getegid()},
+	}); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Dependent on https://github.com/mesg-foundation/engine/pull/1751
Related to https://github.com/mesg-foundation/engine/issues/1741

- fix bug runner/builder/container when current UID and GID are not 0
- Introduce a new structure `runner/builderLCD` that create and stop docker services and returns the msg to broadcast.
- Use it in e2e tests.
- Remove gRPC RunnerClient from e2e test.