### PR TITLE
Use new event API in e2e tests

### DIFF
--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -21,16 +21,13 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/ext/xnet"
 	"github.com/mesg-foundation/engine/hash"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
 type apiclient struct {
-	EventClient pb.EventClient
-	// TODO: to switch when e2e tests doesn't create any event
-	// EventClient     orchestrator.EventClient
+	EventClient     orchestrator.EventClient
 	ExecutionClient orchestrator.ExecutionClient
 	RunnerClient    orchestrator.RunnerClient
 }
@@ -113,9 +110,7 @@ func TestAPI(t *testing.T) {
 	require.NoError(t, err)
 
 	client = &apiclient{
-		EventClient: pb.NewEventClient(conn),
-		// TODO: to switch when e2e tests doesn't create any event
-		// EventClient:     orchestrator.NewEventClient(conn),
+		EventClient:     orchestrator.NewEventClient(conn),
 		ExecutionClient: orchestrator.NewExecutionClient(conn),
 		RunnerClient:    orchestrator.NewRunnerClient(conn),
 	}

--- a/e2e/complex_service_test.go
+++ b/e2e/complex_service_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mesg-foundation/engine/ext/xos"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/protobuf/acknowledgement"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/runner/builder"
 	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	grpcorchestrator "github.com/mesg-foundation/engine/server/grpc/orchestrator"
@@ -77,7 +76,8 @@ func testComplexService(t *testing.T) {
 		require.NoError(t, builder.Start(cont, testServiceComplexStruct, testInstanceComplexHash, testRunnerComplexHash, testServiceComplexImageHash, testInstanceComplexEnv, engineName, enginePort))
 	})
 
-	stream, err := client.EventClient.Stream(context.Background(), &pb.StreamEventRequest{})
+	req := orchestrator.EventStreamRequest{}
+	stream, err := client.EventClient.Stream(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 	require.NoError(t, err)
 	acknowledgement.WaitForStreamToBeReady(stream)
 
@@ -93,7 +93,7 @@ func testComplexService(t *testing.T) {
 			i++
 
 			switch ev.Key {
-			case "test_service_ready", "read_env_ok", "read_env_override_ok", "access_volumes_ok", "access_volumes_from_ok", "resolve_dependence_ok":
+			case "service_ready", "read_env_ok", "read_env_override_ok", "access_volumes_ok", "access_volumes_from_ok", "resolve_dependence_ok":
 				t.Logf("received event %s ", ev.Key)
 			default:
 				t.Fatalf("failed on event %s", ev.Key)

--- a/e2e/definition_test.go
+++ b/e2e/definition_test.go
@@ -24,7 +24,7 @@ var testComplexCreateServiceMsg = &servicemodule.MsgCreate{
 		VolumesFrom: []string{"nginx"},
 	},
 	Events: []*service.Service_Event{
-		{Key: "test_service_ready"},
+		{Key: "service_ready"},
 		{Key: "read_env_ok"},
 		{Key: "read_env_error"},
 		{Key: "read_env_override_ok"},
@@ -36,7 +36,7 @@ var testComplexCreateServiceMsg = &servicemodule.MsgCreate{
 		{Key: "resolve_dependence_ok"},
 		{Key: "resolve_dependence_error"},
 	},
-	Source: "QmYBRgatKfaqwDB6xwjo4GeVnrQzoAba6DhNX2p2kHZRuz",
+	Source: "QmQbobdv3tg1UdPiHBGaqbQF2mjGHPBBNAK4M9hoFA3NVU",
 }
 
 var testCreateServiceMsg = &servicemodule.MsgCreate{
@@ -46,6 +46,25 @@ var testCreateServiceMsg = &servicemodule.MsgCreate{
 		Env: []string{"FOO=1", "BAR=2", "REQUIRED"},
 	},
 	Tasks: []*service.Service_Task{
+		{
+			Key: "task_trigger",
+			Inputs: []*service.Service_Parameter{
+				{
+					Key:  "msg",
+					Type: "String",
+				},
+			},
+			Outputs: []*service.Service_Parameter{
+				{
+					Key:  "msg",
+					Type: "String",
+				},
+				{
+					Key:  "timestamp",
+					Type: "Number",
+				},
+			},
+		},
 		{
 			Key: "task1",
 			Inputs: []*service.Service_Parameter{
@@ -127,13 +146,56 @@ var testCreateServiceMsg = &servicemodule.MsgCreate{
 				},
 			},
 		},
+		{
+			Key: "task_complex_trigger",
+			Inputs: []*service.Service_Parameter{
+				{
+					Key:  "msg",
+					Type: "Object",
+					Object: []*service.Service_Parameter{
+						{
+							Key:  "msg",
+							Type: "String",
+						},
+						{
+							Key:      "array",
+							Type:     "String",
+							Repeated: true,
+							Optional: true,
+						},
+					},
+				},
+			},
+			Outputs: []*service.Service_Parameter{
+				{
+					Key:  "msg",
+					Type: "Object",
+					Object: []*service.Service_Parameter{
+						{
+							Key:  "msg",
+							Type: "String",
+						},
+						{
+							Key:  "timestamp",
+							Type: "Number",
+						},
+						{
+							Key:      "array",
+							Type:     "String",
+							Repeated: true,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
 	},
 	Events: []*service.Service_Event{
 		{
-			Key: "test_service_ready",
+			Key: "service_ready",
 		},
 		{
-			Key: "test_event",
+			Key: "event_trigger",
 			Data: []*service.Service_Parameter{
 				{
 					Key:  "msg",
@@ -146,7 +208,7 @@ var testCreateServiceMsg = &servicemodule.MsgCreate{
 			},
 		},
 		{
-			Key: "test_event_complex",
+			Key: "event_complex_trigger",
 			Data: []*service.Service_Parameter{
 				{
 					Key:  "msg",
@@ -169,19 +231,6 @@ var testCreateServiceMsg = &servicemodule.MsgCreate{
 				},
 			},
 		},
-		{
-			Key: "event_after_task",
-			Data: []*service.Service_Parameter{
-				{
-					Key:  "task_key",
-					Type: "String",
-				},
-				{
-					Key:  "timestamp",
-					Type: "Number",
-				},
-			},
-		},
 	},
-	Source: "QmeGzyEwoNMRGX537K3AGN6B9CBvgKzGu2nVFqyXYzRMjP",
+	Source: "QmXiBMy2rguhPn5hCmHh8rw1jjpq6YcekiUcvh91htVndM",
 }

--- a/e2e/event_test.go
+++ b/e2e/event_test.go
@@ -1,112 +1,106 @@
 package main
 
 import (
-	"context"
 	"testing"
-	"time"
-
-	"github.com/mesg-foundation/engine/hash"
-	"github.com/mesg-foundation/engine/protobuf/acknowledgement"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
-	"github.com/mesg-foundation/engine/protobuf/types"
-	"github.com/stretchr/testify/require"
 )
 
 func testEvent(t *testing.T) {
-	stream, err := client.EventClient.Stream(context.Background(), &pb.StreamEventRequest{
-		Filter: &pb.StreamEventRequest_Filter{},
-	})
-	require.NoError(t, err)
-	acknowledgement.WaitForStreamToBeReady(stream)
+	t.SkipNow()
+	// TODO: cannot create an event so this test is not functional
+	// stream, err := client.EventClient.Stream(context.Background(), &orchestrator.EventStreamRequest{
+	// 	Filter: &orchestrator.EventStreamRequest_Filter{},
+	// }, grpc.PerRPCCredentials(&signCred{req}))
+	// require.NoError(t, err)
+	// acknowledgement.WaitForStreamToBeReady(stream)
 
-	t.Run("simple event", func(t *testing.T) {
-		var (
-			eventHash hash.Hash
-			data      = &types.Struct{
-				Fields: map[string]*types.Value{
-					"msg": {
-						Kind: &types.Value_StringValue{
-							StringValue: "foo",
-						},
-					},
-					"timestamp": {
-						Kind: &types.Value_NumberValue{
-							NumberValue: float64(time.Now().Unix()),
-						},
-					},
-				},
-			}
-		)
-		t.Run("create", func(t *testing.T) {
-			resp, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-				InstanceHash: testInstanceHash,
-				Key:          "test_event",
-				Data:         data,
-			})
-			require.NoError(t, err)
-			eventHash = resp.Hash
-		})
-		t.Run("receive", func(t *testing.T) {
-			event, err := stream.Recv()
-			require.NoError(t, err)
-			require.Equal(t, eventHash, event.Hash)
-			require.Equal(t, testInstanceHash, event.InstanceHash)
-			require.Equal(t, "test_event", event.Key)
-			require.True(t, data.Equal(event.Data))
-		})
-	})
+	// t.Run("simple event", func(t *testing.T) {
+	// 	var (
+	// 		eventHash hash.Hash
+	// 		data      = &types.Struct{
+	// 			Fields: map[string]*types.Value{
+	// 				"msg": {
+	// 					Kind: &types.Value_StringValue{
+	// 						StringValue: "foo",
+	// 					},
+	// 				},
+	// 				"timestamp": {
+	// 					Kind: &types.Value_NumberValue{
+	// 						NumberValue: float64(time.Now().Unix()),
+	// 					},
+	// 				},
+	// 			},
+	// 		}
+	// 	)
+	// 	t.Run("create", func(t *testing.T) {
+	// 		resp, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
+	// 			InstanceHash: testInstanceHash,
+	// 			Key:          "event_trigger",
+	// 			Data:         data,
+	// 		})
+	// 		require.NoError(t, err)
+	// 		eventHash = resp.Hash
+	// 	})
+	// 	t.Run("receive", func(t *testing.T) {
+	// 		event, err := stream.Recv()
+	// 		require.NoError(t, err)
+	// 		require.Equal(t, eventHash, event.Hash)
+	// 		require.Equal(t, testInstanceHash, event.InstanceHash)
+	// 		require.Equal(t, "event_trigger", event.Key)
+	// 		require.True(t, data.Equal(event.Data))
+	// 	})
+	// })
 
-	t.Run("complex event", func(t *testing.T) {
-		var (
-			eventHash hash.Hash
-			data      = &types.Struct{
-				Fields: map[string]*types.Value{
-					"msg": {
-						Kind: &types.Value_StructValue{
-							StructValue: &types.Struct{
-								Fields: map[string]*types.Value{
-									"msg": {
-										Kind: &types.Value_StringValue{
-											StringValue: "complex",
-										},
-									},
-									"timestamp": {
-										Kind: &types.Value_NumberValue{
-											NumberValue: float64(time.Now().Unix()),
-										},
-									},
-									"array": {
-										Kind: &types.Value_ListValue{
-											ListValue: &types.ListValue{Values: []*types.Value{
-												{Kind: &types.Value_StringValue{StringValue: "first"}},
-												{Kind: &types.Value_StringValue{StringValue: "second"}},
-												{Kind: &types.Value_StringValue{StringValue: "third"}},
-											}},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-		)
-		t.Run("create", func(t *testing.T) {
-			resp, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-				InstanceHash: testInstanceHash,
-				Key:          "test_event_complex",
-				Data:         data,
-			})
-			require.NoError(t, err)
-			eventHash = resp.Hash
-		})
-		t.Run("receive", func(t *testing.T) {
-			event, err := stream.Recv()
-			require.NoError(t, err)
-			require.Equal(t, eventHash, event.Hash)
-			require.Equal(t, testInstanceHash, event.InstanceHash)
-			require.Equal(t, "test_event_complex", event.Key)
-			require.True(t, data.Equal(event.Data))
-		})
-	})
+	// t.Run("complex event", func(t *testing.T) {
+	// 	var (
+	// 		eventHash hash.Hash
+	// 		data      = &types.Struct{
+	// 			Fields: map[string]*types.Value{
+	// 				"msg": {
+	// 					Kind: &types.Value_StructValue{
+	// 						StructValue: &types.Struct{
+	// 							Fields: map[string]*types.Value{
+	// 								"msg": {
+	// 									Kind: &types.Value_StringValue{
+	// 										StringValue: "complex",
+	// 									},
+	// 								},
+	// 								"timestamp": {
+	// 									Kind: &types.Value_NumberValue{
+	// 										NumberValue: float64(time.Now().Unix()),
+	// 									},
+	// 								},
+	// 								"array": {
+	// 									Kind: &types.Value_ListValue{
+	// 										ListValue: &types.ListValue{Values: []*types.Value{
+	// 											{Kind: &types.Value_StringValue{StringValue: "first"}},
+	// 											{Kind: &types.Value_StringValue{StringValue: "second"}},
+	// 											{Kind: &types.Value_StringValue{StringValue: "third"}},
+	// 										}},
+	// 									},
+	// 								},
+	// 							},
+	// 						},
+	// 					},
+	// 				},
+	// 			},
+	// 		}
+	// 	)
+	// 	t.Run("create", func(t *testing.T) {
+	// 		resp, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
+	// 			InstanceHash: testInstanceHash,
+	// 			Key:          "event_complex_trigger",
+	// 			Data:         data,
+	// 		})
+	// 		require.NoError(t, err)
+	// 		eventHash = resp.Hash
+	// 	})
+	// 	t.Run("receive", func(t *testing.T) {
+	// 		event, err := stream.Recv()
+	// 		require.NoError(t, err)
+	// 		require.Equal(t, eventHash, event.Hash)
+	// 		require.Equal(t, testInstanceHash, event.InstanceHash)
+	// 		require.Equal(t, "event_complex_trigger", event.Key)
+	// 		require.True(t, data.Equal(event.Data))
+	// 	})
+	// })
 }

--- a/e2e/orchestrator_balance_withdraw_test.go
+++ b/e2e/orchestrator_balance_withdraw_test.go
@@ -9,14 +9,15 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/process"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/protobuf/types"
+	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	"github.com/mesg-foundation/engine/x/ownership"
 	processmodule "github.com/mesg-foundation/engine/x/process"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
-func testOrchestratorProcessBalanceWithdraw(instanceHash hash.Hash) func(t *testing.T) {
+func testOrchestratorProcessBalanceWithdraw(runnerHash, instanceHash hash.Hash) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			processHash hash.Hash
@@ -34,7 +35,7 @@ func testOrchestratorProcessBalanceWithdraw(instanceHash hash.Hash) func(t *test
 						Type: &process.Process_Node_Event_{
 							Event: &process.Process_Node_Event{
 								InstanceHash: instanceHash,
-								EventKey:     "test_event",
+								EventKey:     "event_trigger",
 							},
 						},
 					},
@@ -67,10 +68,11 @@ func testOrchestratorProcessBalanceWithdraw(instanceHash hash.Hash) func(t *test
 			require.True(t, coins.IsEqual(processInitialBalance), coins)
 		})
 		t.Run("trigger process", func(t *testing.T) {
-			_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-				InstanceHash: instanceHash,
-				Key:          "test_event",
-				Data: &types.Struct{
+			req := orchestrator.ExecutionCreateRequest{
+				Price:        "10000atto",
+				TaskKey:      "task_trigger",
+				ExecutorHash: runnerHash,
+				Inputs: &types.Struct{
 					Fields: map[string]*types.Value{
 						"msg": {
 							Kind: &types.Value_StringValue{
@@ -84,7 +86,8 @@ func testOrchestratorProcessBalanceWithdraw(instanceHash hash.Hash) func(t *test
 						},
 					},
 				},
-			})
+			}
+			_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 			require.NoError(t, err)
 		})
 		t.Run("check in progress execution", func(t *testing.T) {

--- a/e2e/orchestrator_event_task_test.go
+++ b/e2e/orchestrator_event_task_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/process"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/protobuf/types"
+	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	processmodule "github.com/mesg-foundation/engine/x/process"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
-func testOrchestratorEventTask(instanceHash hash.Hash) func(t *testing.T) {
+func testOrchestratorEventTask(runnerHash hash.Hash, instanceHash hash.Hash) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			processHash hash.Hash
@@ -31,7 +32,7 @@ func testOrchestratorEventTask(instanceHash hash.Hash) func(t *testing.T) {
 						Type: &process.Process_Node_Event_{
 							Event: &process.Process_Node_Event{
 								InstanceHash: instanceHash,
-								EventKey:     "test_event",
+								EventKey:     "event_trigger",
 							},
 						},
 					},
@@ -53,10 +54,11 @@ func testOrchestratorEventTask(instanceHash hash.Hash) func(t *testing.T) {
 			require.NoError(t, err)
 		})
 		t.Run("trigger process", func(t *testing.T) {
-			_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-				InstanceHash: instanceHash,
-				Key:          "test_event",
-				Data: &types.Struct{
+			req := orchestrator.ExecutionCreateRequest{
+				Price:        "10000atto",
+				TaskKey:      "task_trigger",
+				ExecutorHash: runnerHash,
+				Inputs: &types.Struct{
 					Fields: map[string]*types.Value{
 						"msg": {
 							Kind: &types.Value_StringValue{
@@ -70,7 +72,8 @@ func testOrchestratorEventTask(instanceHash hash.Hash) func(t *testing.T) {
 						},
 					},
 				},
-			})
+			}
+			_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 			require.NoError(t, err)
 		})
 		t.Run("check in progress execution", func(t *testing.T) {

--- a/e2e/orchestrator_filter_path_nested_test.go
+++ b/e2e/orchestrator_filter_path_nested_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/process"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/protobuf/types"
+	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	processmodule "github.com/mesg-foundation/engine/x/process"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
-func testOrchestratorFilterPathNested(instanceHash hash.Hash) func(t *testing.T) {
+func testOrchestratorFilterPathNested(runnerHash, instanceHash hash.Hash) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			processHash hash.Hash
@@ -32,7 +33,7 @@ func testOrchestratorFilterPathNested(instanceHash hash.Hash) func(t *testing.T)
 						Type: &process.Process_Node_Event_{
 							Event: &process.Process_Node_Event{
 								InstanceHash: instanceHash,
-								EventKey:     "test_event_complex",
+								EventKey:     "event_complex_trigger",
 							},
 						},
 					},
@@ -141,10 +142,11 @@ func testOrchestratorFilterPathNested(instanceHash hash.Hash) func(t *testing.T)
 		})
 		t.Run("pass filter", func(t *testing.T) {
 			t.Run("trigger process", func(t *testing.T) {
-				_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-					InstanceHash: instanceHash,
-					Key:          "test_event_complex",
-					Data: &types.Struct{
+				req := orchestrator.ExecutionCreateRequest{
+					Price:        "10000atto",
+					TaskKey:      "task_complex_trigger",
+					ExecutorHash: runnerHash,
+					Inputs: &types.Struct{
 						Fields: map[string]*types.Value{
 							"msg": {
 								Kind: &types.Value_StructValue{
@@ -184,7 +186,8 @@ func testOrchestratorFilterPathNested(instanceHash hash.Hash) func(t *testing.T)
 							},
 						},
 					},
-				})
+				}
+				_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 				require.NoError(t, err)
 			})
 			t.Run("check in progress execution", func(t *testing.T) {
@@ -209,10 +212,11 @@ func testOrchestratorFilterPathNested(instanceHash hash.Hash) func(t *testing.T)
 		})
 		t.Run("stop at filter", func(t *testing.T) {
 			t.Run("trigger process", func(t *testing.T) {
-				_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-					InstanceHash: instanceHash,
-					Key:          "test_event_complex",
-					Data: &types.Struct{
+				req := orchestrator.ExecutionCreateRequest{
+					Price:        "10000atto",
+					TaskKey:      "task_complex_trigger",
+					ExecutorHash: runnerHash,
+					Inputs: &types.Struct{
 						Fields: map[string]*types.Value{
 							"msg": {
 								Kind: &types.Value_StructValue{
@@ -252,7 +256,8 @@ func testOrchestratorFilterPathNested(instanceHash hash.Hash) func(t *testing.T)
 							},
 						},
 					},
-				})
+				}
+				_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 				require.NoError(t, err)
 			})
 			t.Run("wait timeout to check execution is not created", func(t *testing.T) {

--- a/e2e/orchestrator_filter_test.go
+++ b/e2e/orchestrator_filter_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/process"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/protobuf/types"
+	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	processmodule "github.com/mesg-foundation/engine/x/process"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
-func testOrchestratorFilter(instanceHash hash.Hash) func(t *testing.T) {
+func testOrchestratorFilter(runnerHash, instanceHash hash.Hash) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			processHash hash.Hash
@@ -32,7 +33,7 @@ func testOrchestratorFilter(instanceHash hash.Hash) func(t *testing.T) {
 						Type: &process.Process_Node_Event_{
 							Event: &process.Process_Node_Event{
 								InstanceHash: instanceHash,
-								EventKey:     "test_event",
+								EventKey:     "event_trigger",
 							},
 						},
 					},
@@ -97,10 +98,11 @@ func testOrchestratorFilter(instanceHash hash.Hash) func(t *testing.T) {
 		})
 		t.Run("pass filter", func(t *testing.T) {
 			t.Run("trigger process", func(t *testing.T) {
-				_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-					InstanceHash: instanceHash,
-					Key:          "test_event",
-					Data: &types.Struct{
+				req := orchestrator.ExecutionCreateRequest{
+					Price:        "10000atto",
+					TaskKey:      "task_trigger",
+					ExecutorHash: runnerHash,
+					Inputs: &types.Struct{
 						Fields: map[string]*types.Value{
 							"msg": {
 								Kind: &types.Value_StringValue{
@@ -114,7 +116,8 @@ func testOrchestratorFilter(instanceHash hash.Hash) func(t *testing.T) {
 							},
 						},
 					},
-				})
+				}
+				_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 				require.NoError(t, err)
 			})
 			t.Run("check in progress execution", func(t *testing.T) {
@@ -139,10 +142,11 @@ func testOrchestratorFilter(instanceHash hash.Hash) func(t *testing.T) {
 		})
 		t.Run("stop at filter", func(t *testing.T) {
 			t.Run("trigger process", func(t *testing.T) {
-				_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-					InstanceHash: instanceHash,
-					Key:          "test_event",
-					Data: &types.Struct{
+				req := orchestrator.ExecutionCreateRequest{
+					Price:        "10000atto",
+					TaskKey:      "task_trigger",
+					ExecutorHash: runnerHash,
+					Inputs: &types.Struct{
 						Fields: map[string]*types.Value{
 							"msg": {
 								Kind: &types.Value_StringValue{
@@ -156,7 +160,8 @@ func testOrchestratorFilter(instanceHash hash.Hash) func(t *testing.T) {
 							},
 						},
 					},
-				})
+				}
+				_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 				require.NoError(t, err)
 			})
 			t.Run("wait timeout to check execution is not created", func(t *testing.T) {

--- a/e2e/orchestrator_map_const_test.go
+++ b/e2e/orchestrator_map_const_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/process"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/protobuf/types"
+	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	processmodule "github.com/mesg-foundation/engine/x/process"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
-func testOrchestratorMapConst(instanceHash hash.Hash) func(t *testing.T) {
+func testOrchestratorMapConst(runnerHash, instanceHash hash.Hash) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			processHash hash.Hash
@@ -31,7 +32,7 @@ func testOrchestratorMapConst(instanceHash hash.Hash) func(t *testing.T) {
 						Type: &process.Process_Node_Event_{
 							Event: &process.Process_Node_Event{
 								InstanceHash: instanceHash,
-								EventKey:     "test_event",
+								EventKey:     "event_trigger",
 							},
 						},
 					},
@@ -68,10 +69,11 @@ func testOrchestratorMapConst(instanceHash hash.Hash) func(t *testing.T) {
 			require.NoError(t, err)
 		})
 		t.Run("trigger process", func(t *testing.T) {
-			_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-				InstanceHash: instanceHash,
-				Key:          "test_event",
-				Data: &types.Struct{
+			req := orchestrator.ExecutionCreateRequest{
+				Price:        "10000atto",
+				TaskKey:      "task_trigger",
+				ExecutorHash: runnerHash,
+				Inputs: &types.Struct{
 					Fields: map[string]*types.Value{
 						"msg": {
 							Kind: &types.Value_StringValue{
@@ -85,7 +87,8 @@ func testOrchestratorMapConst(instanceHash hash.Hash) func(t *testing.T) {
 						},
 					},
 				},
-			})
+			}
+			_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 			require.NoError(t, err)
 		})
 		t.Run("check in progress execution", func(t *testing.T) {

--- a/e2e/orchestrator_ref_grand_parent_task_test.go
+++ b/e2e/orchestrator_ref_grand_parent_task_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/process"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/protobuf/types"
+	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	processmodule "github.com/mesg-foundation/engine/x/process"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
-func testOrchestratorRefGrandParentTask(instanceHash hash.Hash) func(t *testing.T) {
+func testOrchestratorRefGrandParentTask(runnerHash, instanceHash hash.Hash) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			processHash hash.Hash
@@ -30,7 +31,7 @@ func testOrchestratorRefGrandParentTask(instanceHash hash.Hash) func(t *testing.
 						Type: &process.Process_Node_Event_{
 							Event: &process.Process_Node_Event{
 								InstanceHash: instanceHash,
-								EventKey:     "test_event",
+								EventKey:     "event_trigger",
 							},
 						},
 					},
@@ -109,10 +110,11 @@ func testOrchestratorRefGrandParentTask(instanceHash hash.Hash) func(t *testing.
 			require.NoError(t, err)
 		})
 		t.Run("trigger process", func(t *testing.T) {
-			_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-				InstanceHash: instanceHash,
-				Key:          "test_event",
-				Data: &types.Struct{
+			req := orchestrator.ExecutionCreateRequest{
+				Price:        "10000atto",
+				TaskKey:      "task_trigger",
+				ExecutorHash: runnerHash,
+				Inputs: &types.Struct{
 					Fields: map[string]*types.Value{
 						"msg": {
 							Kind: &types.Value_StringValue{
@@ -126,7 +128,8 @@ func testOrchestratorRefGrandParentTask(instanceHash hash.Hash) func(t *testing.
 						},
 					},
 				},
-			})
+			}
+			_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 			require.NoError(t, err)
 		})
 		t.Run("check first task", func(t *testing.T) {

--- a/e2e/orchestrator_ref_path_nested_test.go
+++ b/e2e/orchestrator_ref_path_nested_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/mesg-foundation/engine/execution"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/process"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/protobuf/types"
+	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
 	processmodule "github.com/mesg-foundation/engine/x/process"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
-func testOrchestratorRefPathNested(instanceHash hash.Hash) func(t *testing.T) {
+func testOrchestratorRefPathNested(runnerHash, instanceHash hash.Hash) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			processHash hash.Hash
@@ -31,7 +32,7 @@ func testOrchestratorRefPathNested(instanceHash hash.Hash) func(t *testing.T) {
 						Type: &process.Process_Node_Event_{
 							Event: &process.Process_Node_Event{
 								InstanceHash: instanceHash,
-								EventKey:     "test_event_complex",
+								EventKey:     "event_complex_trigger",
 							},
 						},
 					},
@@ -198,43 +199,44 @@ func testOrchestratorRefPathNested(instanceHash hash.Hash) func(t *testing.T) {
 			processHash, err = lcd.BroadcastMsg(msg)
 			require.NoError(t, err)
 		})
-		data := &types.Struct{
-			Fields: map[string]*types.Value{
-				"msg": {
-					Kind: &types.Value_StructValue{
-						StructValue: &types.Struct{
-							Fields: map[string]*types.Value{
-								"msg": {
-									Kind: &types.Value_StringValue{
-										StringValue: "complex",
-									},
-								},
-								"timestamp": {
-									Kind: &types.Value_NumberValue{
-										NumberValue: float64(time.Now().Unix()),
-									},
-								},
-								"array": {
-									Kind: &types.Value_ListValue{
-										ListValue: &types.ListValue{Values: []*types.Value{
-											{Kind: &types.Value_StringValue{StringValue: "first"}},
-											{Kind: &types.Value_StringValue{StringValue: "second"}},
-											{Kind: &types.Value_StringValue{StringValue: "third"}},
-										}},
+		t.Run("trigger process", func(t *testing.T) {
+			req := orchestrator.ExecutionCreateRequest{
+				Price:        "10000atto",
+				TaskKey:      "task_complex_trigger",
+				ExecutorHash: runnerHash,
+				Inputs: &types.Struct{
+					Fields: map[string]*types.Value{
+						"msg": {
+							Kind: &types.Value_StructValue{
+								StructValue: &types.Struct{
+									Fields: map[string]*types.Value{
+										"msg": {
+											Kind: &types.Value_StringValue{
+												StringValue: "complex",
+											},
+										},
+										"timestamp": {
+											Kind: &types.Value_NumberValue{
+												NumberValue: float64(time.Now().Unix()),
+											},
+										},
+										"array": {
+											Kind: &types.Value_ListValue{
+												ListValue: &types.ListValue{Values: []*types.Value{
+													{Kind: &types.Value_StringValue{StringValue: "first"}},
+													{Kind: &types.Value_StringValue{StringValue: "second"}},
+													{Kind: &types.Value_StringValue{StringValue: "third"}},
+												}},
+											},
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-		}
-		t.Run("trigger process", func(t *testing.T) {
-			_, err := client.EventClient.Create(context.Background(), &pb.CreateEventRequest{
-				InstanceHash: instanceHash,
-				Key:          "test_event_complex",
-				Data:         data,
-			})
+			}
+			_, err := client.ExecutionClient.Create(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 			require.NoError(t, err)
 		})
 		t.Run("first ref", func(t *testing.T) {

--- a/e2e/orchestrator_test.go
+++ b/e2e/orchestrator_test.go
@@ -6,14 +6,14 @@ import (
 
 func testOrchestrator(t *testing.T) {
 	// running orchestrator tests
-	t.Run("process balance and withdraw", testOrchestratorProcessBalanceWithdraw(testInstanceHash))
-	t.Run("event task", testOrchestratorEventTask(testInstanceHash))
+	t.Run("process balance and withdraw", testOrchestratorProcessBalanceWithdraw(testRunnerHash, testInstanceHash))
+	t.Run("event task", testOrchestratorEventTask(testRunnerHash, testInstanceHash))
 	t.Run("result task", testOrchestratorResultTask(testRunnerHash, testInstanceHash))
-	t.Run("map const", testOrchestratorMapConst(testInstanceHash))
-	t.Run("ref grand parent task", testOrchestratorRefGrandParentTask(testInstanceHash))
-	t.Run("nested data", testOrchestratorNestedData(testInstanceHash))
-	t.Run("nested map", testOrchestratorNestedMap(testInstanceHash))
-	t.Run("ref path nested", testOrchestratorRefPathNested(testInstanceHash))
-	t.Run("filter", testOrchestratorFilter(testInstanceHash))
-	t.Run("filter path nested", testOrchestratorFilterPathNested(testInstanceHash))
+	t.Run("map const", testOrchestratorMapConst(testRunnerHash, testInstanceHash))
+	t.Run("ref grand parent task", testOrchestratorRefGrandParentTask(testRunnerHash, testInstanceHash))
+	t.Run("nested data", testOrchestratorNestedData(testRunnerHash, testInstanceHash))
+	t.Run("nested map", testOrchestratorNestedMap(testRunnerHash, testInstanceHash))
+	t.Run("ref path nested", testOrchestratorRefPathNested(testRunnerHash, testInstanceHash))
+	t.Run("filter", testOrchestratorFilter(testRunnerHash, testInstanceHash))
+	t.Run("filter path nested", testOrchestratorFilterPathNested(testRunnerHash, testInstanceHash))
 }

--- a/e2e/process_test.go
+++ b/e2e/process_test.go
@@ -26,7 +26,7 @@ func testProcess(t *testing.T) {
 					Type: &process.Process_Node_Event_{
 						Event: &process.Process_Node_Event{
 							InstanceHash: testInstanceHash,
-							EventKey:     "test_service_ready",
+							EventKey:     "service_ready",
 						},
 					},
 				},
@@ -35,7 +35,7 @@ func testProcess(t *testing.T) {
 					Type: &process.Process_Node_Task_{
 						Task: &process.Process_Node_Task{
 							InstanceHash: testInstanceHash,
-							TaskKey:      "test_service_ready",
+							TaskKey:      "service_ready",
 						},
 					},
 				},

--- a/e2e/runner_test.go
+++ b/e2e/runner_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mesg-foundation/engine/ext/xos"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/protobuf/acknowledgement"
-	pb "github.com/mesg-foundation/engine/protobuf/api"
 	"github.com/mesg-foundation/engine/runner"
 	"github.com/mesg-foundation/engine/runner/builder"
 	"github.com/mesg-foundation/engine/server/grpc/orchestrator"
@@ -62,11 +61,12 @@ func testRunner(t *testing.T) {
 	})
 
 	t.Run("wait for service to be ready", func(t *testing.T) {
-		stream, err := client.EventClient.Stream(context.Background(), &pb.StreamEventRequest{
-			Filter: &pb.StreamEventRequest_Filter{
-				Key: "test_service_ready",
+		req := orchestrator.EventStreamRequest{
+			Filter: &orchestrator.EventStreamRequest_Filter{
+				Key: "service_ready",
 			},
-		})
+		}
+		stream, err := client.EventClient.Stream(context.Background(), &req, grpc.PerRPCCredentials(&signCred{req}))
 		require.NoError(t, err)
 		acknowledgement.WaitForStreamToBeReady(stream)
 

--- a/e2e/testdata/test-complex-service/main.go
+++ b/e2e/testdata/test-complex-service/main.go
@@ -110,7 +110,7 @@ func main() {
 	// give some time to nginx to start
 	time.Sleep(10 * time.Second)
 
-	sendEvent(client, token, "test_service_ready")
+	sendEvent(client, token, "service_ready")
 
 	// check env default value
 	if os.Getenv("ENVA") == "do_not_override" {

--- a/e2e/testdata/test-complex-service/mesg.yml
+++ b/e2e/testdata/test-complex-service/mesg.yml
@@ -17,7 +17,7 @@ dependencies:
       - /etc/nginx
 
 events:
-  test_service_ready:
+  service_ready:
 
   read_env_ok:
   read_env_error:

--- a/e2e/testdata/test-service/mesg.yml
+++ b/e2e/testdata/test-service/mesg.yml
@@ -6,26 +6,23 @@ configuration:
     - BAR=2
     - REQUIRED
 tasks:
+  task_trigger:
+    inputs: &simpleInputs
+      msg:
+        type: String
+    outputs: &simpleOutputs
+      msg:
+        type: String
+      timestamp:
+        type: Number
   task1:
-    inputs:
-      msg:
-        type: String
-    outputs:
-      msg:
-        type: String
-      timestamp:
-        type: Number
+    inputs: *simpleInputs
+    outputs: *simpleOutputs
   task2:
-    inputs:
-      msg:
-        type: String
-    outputs:
-      msg:
-        type: String
-      timestamp:
-        type: Number
+    inputs: *simpleInputs
+    outputs: *simpleOutputs
   task_complex:
-    inputs:
+    inputs: &complexInputs
       msg:
         type: Object
         object:
@@ -35,7 +32,7 @@ tasks:
             type: String
             repeated: true
             optional: true
-    outputs:
+    outputs: &complexOutputs
       msg:
         type: Object
         object:
@@ -47,29 +44,12 @@ tasks:
             type: String
             repeated: true
             optional: true
+  task_complex_trigger:
+    inputs: *complexInputs
+    outputs: *complexOutputs
 events:
-  test_service_ready:
-  test_event:
-    data:
-      msg:
-        type: String
-      timestamp:
-        type: Number
-  test_event_complex:
-    data:
-      msg:
-        type: Object
-        object:
-          msg:
-            type: String
-          timestamp:
-            type: Number
-          array:
-            type: String
-            repeated: true
-  event_after_task:
-    data:
-      task_key:
-        type: String
-      timestamp:
-        type: Number
+  service_ready:
+  event_trigger:
+    data: *simpleOutputs
+  event_complex_trigger:
+    data: *complexOutputs


### PR DESCRIPTION
Dependent on https://github.com/mesg-foundation/engine/pull/1771

This PR updates the e2e tests to use the new event API.
As there is no `CreateEvent` endpoint anymore, I changed the e2e services and processes to get around this.

Diff:
https://github.com/mesg-foundation/engine/pull/1773/files/2d0ef86bce473b75b61b526d47f49c7a1140ae8b..fdecdda4d5beb336980e2145ba050872236a0682