### PR TITLE
Add info to cosmos version on build

### DIFF
--- a/cmd/mesg-cli/main.go
+++ b/cmd/mesg-cli/main.go
@@ -46,8 +46,8 @@ func main() {
 	cosmos.CustomizeConfig(cfg)
 
 	rootCmd := &cobra.Command{
-		Use:   "mesg-cli",
-		Short: "Command line interface for interacting with appd",
+		Use:   version.ClientName,
+		Short: "Command line interface for interacting with " + version.Name,
 	}
 
 	// Add --chain-id to persistent flags and mark it required

--- a/cmd/mesg-daemon/main.go
+++ b/cmd/mesg-daemon/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/staking"
@@ -47,8 +48,8 @@ func main() {
 	ctx := server.NewDefaultContext()
 	cobra.EnableCommandSorting = false
 	rootCmd := &cobra.Command{
-		Use:               "mesg-daemon",
-		Short:             "app Daemon (server)",
+		Use:               version.ServerName,
+		Short:             "Engine Daemon (server)",
 		PersistentPreRunE: server.PersistentPreRunEFn(ctx),
 	}
 

--- a/scripts/publish-cmds.sh
+++ b/scripts/publish-cmds.sh
@@ -6,7 +6,7 @@ if [[ -z "$1" || -z "$2" || ( "$2" != "dev" && "$2" != "prod" ) ]]; then
   exit 1
 fi
 
-LDFLAGS="-s -w -X 'github.com/mesg-foundation/engine/version.Version=$1'"
+LDFLAGS="-s -w -X 'github.com/mesg-foundation/engine/version.Version=$1' -X 'github.com/cosmos/cosmos-sdk/version.Name=mesg' -X 'github.com/cosmos/cosmos-sdk/version.ServerName=mesg-daemon' -X 'github.com/cosmos/cosmos-sdk/version.ClientName=mesg-cli' -X 'github.com/cosmos/cosmos-sdk/version.Version=$1'"
 archs=(amd64 386)
 oss=(linux darwin)
 


### PR DESCRIPTION
Add info to cosmos package `version` on build to setup the client name, server name, and version.

closes https://github.com/mesg-foundation/engine/issues/1736