### PR TITLE
Calculate the instance env hash with only the customized env

### DIFF
--- a/server/grpc/orchestrator/runner.pb.go
+++ b/server/grpc/orchestrator/runner.pb.go
@@ -30,7 +30,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type RunnerRegisterRequest struct {
 	// Service's hash to start the runner with.
 	ServiceHash github_com_mesg_foundation_engine_hash.Hash `protobuf:"bytes,1,opt,name=serviceHash,proto3,casttype=github.com/mesg-foundation/engine/hash.Hash" json:"serviceHash,omitempty" validate:"required,hash"`
-	// Hash of the environmental variables to start the runner with.
+	// Hash of the customized environmental variables (not the ones in the service configuration).
 	EnvHash              github_com_mesg_foundation_engine_hash.Hash `protobuf:"bytes,2,opt,name=envHash,proto3,casttype=github.com/mesg-foundation/engine/hash.Hash" json:"envHash,omitempty" validate:"omitempty,hash"`
 	XXX_NoUnkeyedLiteral struct{}                                    `json:"-"`
 	XXX_unrecognized     []byte                                      `json:"-"`

--- a/server/grpc/orchestrator/runner.proto
+++ b/server/grpc/orchestrator/runner.proto
@@ -25,7 +25,7 @@ message RunnerRegisterRequest {
     (gogoproto.casttype) = "github.com/mesg-foundation/engine/hash.Hash"
   ];
 
-  // Hash of the environmental variables to start the runner with.
+  // Hash of the customized environmental variables (not the ones in the service configuration).
   bytes envHash = 2 [
     (gogoproto.moretags) = 'validate:"omitempty,hash"',
     (gogoproto.casttype) = "github.com/mesg-foundation/engine/hash.Hash"

--- a/x/runner/client/rest/query.go
+++ b/x/runner/client/rest/query.go
@@ -8,11 +8,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
-	"github.com/mesg-foundation/engine/ext/xos"
 	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/instance"
 	"github.com/mesg-foundation/engine/runner"
-	"github.com/mesg-foundation/engine/service"
 	"github.com/mesg-foundation/engine/x/runner/internal/types"
 )
 
@@ -138,18 +136,7 @@ func queryHashHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		srvRes, _, err := cliCtx.Query("custom/service/get/" + req.ServiceHash.String())
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		var srv service.Service
-		if err := cliCtx.Codec.UnmarshalJSON(srvRes, &srv); err != nil {
-			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		envHash := hash.Dump(xos.EnvMergeSlices(srv.Configuration.Env, req.Env))
+		envHash := hash.Dump(req.Env)
 		inst, err := instance.New(req.ServiceHash, envHash)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/x/runner/internal/types/msg.pb.go
+++ b/x/runner/internal/types/msg.pb.go
@@ -29,7 +29,7 @@ type MsgCreate struct {
 	Owner github_com_cosmos_cosmos_sdk_types.AccAddress `protobuf:"bytes,1,opt,name=owner,proto3,casttype=github.com/cosmos/cosmos-sdk/types.AccAddress" json:"owner,omitempty" validate:"required,accaddress"`
 	// Service's hash to start the runner with.
 	ServiceHash github_com_mesg_foundation_engine_hash.Hash `protobuf:"bytes,2,opt,name=serviceHash,proto3,casttype=github.com/mesg-foundation/engine/hash.Hash" json:"serviceHash,omitempty" validate:"required,hash"`
-	// Environmental variables to start the runner with.
+	// Hash of the customized environmental variables (not the ones in the service configuration).
 	EnvHash              github_com_mesg_foundation_engine_hash.Hash `protobuf:"bytes,3,opt,name=envHash,proto3,casttype=github.com/mesg-foundation/engine/hash.Hash" json:"envHash,omitempty" validate:"omitempty,hash"`
 	XXX_NoUnkeyedLiteral struct{}                                    `json:"-"`
 	XXX_unrecognized     []byte                                      `json:"-"`

--- a/x/runner/internal/types/msg.proto
+++ b/x/runner/internal/types/msg.proto
@@ -19,7 +19,7 @@ message MsgCreate {
     (gogoproto.casttype) = "github.com/mesg-foundation/engine/hash.Hash"
   ];
 
-  // Environmental variables to start the runner with.
+  // Hash of the customized environmental variables (not the ones in the service configuration).
   bytes envHash = 3 [
     (gogoproto.moretags) = 'validate:"omitempty,hash"',
     (gogoproto.casttype) = "github.com/mesg-foundation/engine/hash.Hash"


### PR DESCRIPTION
Calculate the instance env hash with only the customized env instead of the merge of the default env and customized