### PR TITLE
Release v0.22.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,25 +158,6 @@ workflows:
           requires:
             - "test_e2e"
 
-  test_prod:
-    jobs:
-      - "test":
-          filters:
-            tags:
-              ignore: /.*/
-            branches:
-              only: master
-      - "lint":
-          filters:
-            tags:
-              ignore: /.*/
-            branches:
-              only: master
-      - "test_e2e":
-          requires:
-            - "test"
-            - "lint"
-
   release_prod:
     jobs:
       - "lint":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.22.0](https://github.com/mesg-foundation/engine/releases/tag/v0.22.0)
+
+#### Breaking Changes
+
+- ([#1785](https://github.com/mesg-foundation/engine/pull/1785)) Replace bech32 prefix from "mesgtest" to "mesg".
+
 ## [v0.21.0](https://github.com/mesg-foundation/engine/releases/tag/v0.21.0)
 
 #### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [v0.21.0](https://github.com/mesg-foundation/engine/releases/tag/v0.21.0)
+
+#### Breaking Changes
+
+- ([#1737](https://github.com/mesg-foundation/engine/pull/1737)) Add support for any type of data to filter.
+- ([#1739](https://github.com/mesg-foundation/engine/pull/1739)) Add reference system to filter.
+- ([#1774](https://github.com/mesg-foundation/engine/pull/1774)) Remove deprecated gRPC API.
+- ([#1783](https://github.com/mesg-foundation/engine/pull/1783)) Calculate the instance env hash with only the customized env.
+
+#### Added
+
+- ([#1737](https://github.com/mesg-foundation/engine/pull/1737)) Add support for any type of data to filter.
+- ([#1739](https://github.com/mesg-foundation/engine/pull/1739)) Add reference system to filter.
+- ([#1749](https://github.com/mesg-foundation/engine/pull/1749)) Add more validation on resources.
+- ([#1758](https://github.com/mesg-foundation/engine/pull/1758)) Introduce a simple LCD client.
+- ([#1759](https://github.com/mesg-foundation/engine/pull/1759)) add 2 more linters and remove useless exclusion.
+- ([#1767](https://github.com/mesg-foundation/engine/pull/1767)) New Runner gRPC API.
+- ([#1768](https://github.com/mesg-foundation/engine/pull/1768)) Add lcd endpoints and commands exists to runner and process.
+- ([#1771](https://github.com/mesg-foundation/engine/pull/1771)) Add Orchestrator gRPC API.
+- ([#1780](https://github.com/mesg-foundation/engine/pull/1780)) Add info to cosmos version on build.
+
+#### Changed
+
+- ([#1751](https://github.com/mesg-foundation/engine/pull/1751)) Replace gRPC by LCD as much as possible from e2e tests.
+- ([#1754](https://github.com/mesg-foundation/engine/pull/1754)) Update lcd service hash endpoint to use a dedicated request structure.
+- ([#1755](https://github.com/mesg-foundation/engine/pull/1755)) Update lcd process hash endpoint to use a dedicated request structure.
+- ([#1756](https://github.com/mesg-foundation/engine/pull/1756)) Change gogoproto's customtype to casttype.
+- ([#1757](https://github.com/mesg-foundation/engine/pull/1757)) Replace runner gRPC by LCD in e2e tests.
+- ([#1761](https://github.com/mesg-foundation/engine/pull/1761)) Remove module suffix from lot of places.
+- ([#1769](https://github.com/mesg-foundation/engine/pull/1769)) Update cosmos events.
+- ([#1773](https://github.com/mesg-foundation/engine/pull/1773)) Use new event API in e2e tests.
+- ([#1775](https://github.com/mesg-foundation/engine/pull/1775)) Simplify container.
+- ([#1781](https://github.com/mesg-foundation/engine/pull/1781)) Switch back to default staking coins of cosmos.
+
+#### Fixed
+
+- ([#1746](https://github.com/mesg-foundation/engine/pull/1746)) Add "dive" validation to all repeated message in the proto files.
+- ([#1762](https://github.com/mesg-foundation/engine/pull/1762)) Fix account sequence desynchronisation when error.
+
+#### Dependencies
+
+- ([#1752](https://github.com/mesg-foundation/engine/pull/1752)) Update to cosmos-sdk v0.38.2 and tendermint v0.33.2.
+
 ## [v0.20.0](https://github.com/mesg-foundation/engine/releases/tag/v0.20.0)
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@
 
 #### Added
 
-- ([#1737](https://github.com/mesg-foundation/engine/pull/1737)) Add support for any type of data to filter.
-- ([#1739](https://github.com/mesg-foundation/engine/pull/1739)) Add reference system to filter.
 - ([#1749](https://github.com/mesg-foundation/engine/pull/1749)) Add more validation on resources.
 - ([#1758](https://github.com/mesg-foundation/engine/pull/1758)) Introduce a simple LCD client.
 - ([#1759](https://github.com/mesg-foundation/engine/pull/1759)) add 2 more linters and remove useless exclusion.

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// CosmosBech32MainPrefix defines the main Bech32 prefix.
-	CosmosBech32MainPrefix = "mesgtest"
+	CosmosBech32MainPrefix = "mesg"
 
 	// CosmosCoinType is the mesg registered coin type from https://github.com/satoshilabs/slips/blob/master/slip-0044.md.
 	CosmosCoinType = uint32(470)

--- a/e2e/testdata/e2e.config.yml
+++ b/e2e/testdata/e2e.config.yml
@@ -1,5 +1,5 @@
 authorized_pubkeys:
-  - mesgtestpub1addwnpepqg0ujk8vcwq86z8466rznfvfz5rk992wsy0qtczfedgsy3x90mrzk476x05
+  - mesgpub1addwnpepqg0ujk8vcwq86z8466rznfvfz5rk992wsy0qtczfedgsy3x90mrzkcd5srf
 account:
   mnemonic: glimpse upon body vast economy give taxi yellow rabbit come click ranch chronic hammer sport near rotate charge lumber chicken cloud base thing forum
 tendermint:


### PR DESCRIPTION
#### Breaking Changes

- ([#1785](https://github.com/mesg-foundation/engine/pull/1785)) Replace bech32 prefix from "mesgtest" to "mesg".