### PR TITLE
Add lcd endpoint to estimate the gas of a transaction

### DIFF
--- a/cmd/mesg-cli/main.go
+++ b/cmd/mesg-cli/main.go
@@ -136,6 +136,7 @@ func registerRoutes(rs *lcd.RestServer) {
 	client.RegisterRoutes(rs.CliCtx, rs.Mux)
 	authrest.RegisterTxRoutes(rs.CliCtx, rs.Mux)
 	app.ModuleBasics.RegisterRESTRoutes(rs.CliCtx, rs.Mux)
+	cosmos.RegisterEstimateGasRoute(rs.CliCtx, rs.Mux)
 }
 
 func initConfig(cmd *cobra.Command) error {

--- a/cmd/mesg-cli/main.go
+++ b/cmd/mesg-cli/main.go
@@ -136,7 +136,7 @@ func registerRoutes(rs *lcd.RestServer) {
 	client.RegisterRoutes(rs.CliCtx, rs.Mux)
 	authrest.RegisterTxRoutes(rs.CliCtx, rs.Mux)
 	app.ModuleBasics.RegisterRESTRoutes(rs.CliCtx, rs.Mux)
-	cosmos.RegisterEstimateGasRoute(rs.CliCtx, rs.Mux)
+	cosmos.RegisterSimulateRoute(rs.CliCtx, rs.Mux)
 }
 
 func initConfig(cmd *cobra.Command) error {

--- a/core/main.go
+++ b/core/main.go
@@ -208,6 +208,7 @@ func main() {
 	cosmosclient.RegisterRoutes(cliCtx, mux)
 	authrest.RegisterTxRoutes(cliCtx, mux)
 	app.ModuleBasics.RegisterRESTRoutes(cliCtx, mux)
+	cosmos.RegisterEstimateGasRoute(cliCtx, mux)
 	go func() {
 		if err := rpcserver.StartHTTPServer(lcdServer, mux, tendermintLogger, cfgLcd); err != nil {
 			logrus.WithField("module", "main").Warnln(err) // not a fatal because closing the connection return an error here

--- a/core/main.go
+++ b/core/main.go
@@ -208,7 +208,7 @@ func main() {
 	cosmosclient.RegisterRoutes(cliCtx, mux)
 	authrest.RegisterTxRoutes(cliCtx, mux)
 	app.ModuleBasics.RegisterRESTRoutes(cliCtx, mux)
-	cosmos.RegisterEstimateGasRoute(cliCtx, mux)
+	cosmos.RegisterSimulateRoute(cliCtx, mux)
 	go func() {
 		if err := rpcserver.StartHTTPServer(lcdServer, mux, tendermintLogger, cfgLcd); err != nil {
 			logrus.WithField("module", "main").Warnln(err) // not a fatal because closing the connection return an error here

--- a/cosmos/config.go
+++ b/cosmos/config.go
@@ -31,3 +31,6 @@ func InitConfig() {
 	cfg.SetCoinType(config.CosmosCoinType)
 	cfg.Seal()
 }
+
+// GasAdjustment is a multiplier to make sure transactions have enough gas when gas are estimated.
+const GasAdjustment = 1.5

--- a/cosmos/estimategas.go
+++ b/cosmos/estimategas.go
@@ -13,7 +13,7 @@ import (
 
 // RegisterEstimateGasRoute regiters the route on the router.
 func RegisterEstimateGasRoute(cliCtx context.CLIContext, r *mux.Router) {
-	r.HandleFunc("/txs/estimategas", EstimateGasRequestHandlerFn(cliCtx)).Methods("POST")
+	r.HandleFunc("/txs/simulate", EstimateGasRequestHandlerFn(cliCtx)).Methods("POST")
 }
 
 // EstimateGasReq defines the properties of a send request's body.

--- a/cosmos/estimategas.go
+++ b/cosmos/estimategas.go
@@ -1,0 +1,42 @@
+package cosmos
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+)
+
+// RegisterEstimateGasRoute regiters the route on the router.
+func RegisterEstimateGasRoute(cliCtx context.CLIContext, r *mux.Router) {
+	r.HandleFunc("/txs/estimategas", EstimateGasRequestHandlerFn(cliCtx)).Methods("POST")
+}
+
+// EstimateGasReq defines the properties of a send request's body.
+type EstimateGasReq struct {
+	BaseReq rest.BaseReq `json:"base_req" yaml:"base_req"`
+	Msgs    []sdk.Msg    `json:"msgs" yaml:"msgs"`
+}
+
+// EstimateGasRequestHandlerFn - http request handler to estimate gas.
+func EstimateGasRequestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req EstimateGasReq
+		if !rest.ReadRESTReq(w, r, cliCtx.Codec, &req) {
+			return
+		}
+
+		req.BaseReq = req.BaseReq.Sanitize()
+		if !req.BaseReq.ValidateBasic(w) {
+			return
+		}
+
+		// force simulate to true to use the following function in simulate only mode.
+		req.BaseReq.Simulate = true
+		utils.WriteGenerateStdTxResponse(w, cliCtx, req.BaseReq, req.Msgs)
+	}
+}

--- a/cosmos/lcd.go
+++ b/cosmos/lcd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"sync"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -207,7 +208,7 @@ func (lcd *LCD) createAndSignTx(msgs []sdk.Msg, acc *auth.BaseAccount) (authtype
 		acc.GetAccountNumber(),
 		acc.GetSequence(),
 		flags.DefaultGasLimit,
-		flags.DefaultGasAdjustment,
+		GasAdjustment,
 		true,
 		lcd.chainID,
 		"",
@@ -217,9 +218,22 @@ func (lcd *LCD) createAndSignTx(msgs []sdk.Msg, acc *auth.BaseAccount) (authtype
 
 	// calculate gas
 	if txBuilder.SimulateAndExecute() {
+		gasAdjustment := strconv.FormatFloat(txBuilder.GasAdjustment(), 'f', -1, 64)
+		fmt.Println("gasAdjustment", gasAdjustment)
 		req := SimulateReq{
-			BaseReq: rest.NewBaseReq(acc.Address.String(), "", lcd.chainID, "", "1.5", acc.GetAccountNumber(), acc.GetSequence(), nil, nil, true),
-			Msgs:    msgs,
+			BaseReq: rest.NewBaseReq(
+				acc.Address.String(),
+				"",
+				lcd.chainID,
+				"",
+				gasAdjustment,
+				acc.GetAccountNumber(),
+				acc.GetSequence(),
+				nil,
+				nil,
+				true,
+			),
+			Msgs: msgs,
 		}
 		var res rest.GasEstimateResponse
 		if err := lcd.PostBare("txs/simulate", req, &res); err != nil {

--- a/cosmos/rpc.go
+++ b/cosmos/rpc.go
@@ -208,7 +208,7 @@ func (c *RPC) createAndSignTx(msgs []sdktypes.Msg, acc authExported.Account) (te
 		acc.GetAccountNumber(),
 		acc.GetSequence(),
 		flags.DefaultGasLimit,
-		flags.DefaultGasAdjustment,
+		GasAdjustment,
 		true,
 		c.chainID,
 		"",

--- a/cosmos/simulate.go
+++ b/cosmos/simulate.go
@@ -11,21 +11,21 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 )
 
-// RegisterEstimateGasRoute regiters the route on the router.
-func RegisterEstimateGasRoute(cliCtx context.CLIContext, r *mux.Router) {
-	r.HandleFunc("/txs/simulate", EstimateGasRequestHandlerFn(cliCtx)).Methods("POST")
+// RegisterSimulateRoute registers the route on the router.
+func RegisterSimulateRoute(cliCtx context.CLIContext, r *mux.Router) {
+	r.HandleFunc("/txs/simulate", SimulateRequestHandlerFn(cliCtx)).Methods("POST")
 }
 
-// EstimateGasReq defines the properties of a send request's body.
-type EstimateGasReq struct {
+// SimulateReq defines the properties of a send request's body.
+type SimulateReq struct {
 	BaseReq rest.BaseReq `json:"base_req" yaml:"base_req"`
 	Msgs    []sdk.Msg    `json:"msgs" yaml:"msgs"`
 }
 
-// EstimateGasRequestHandlerFn - http request handler to estimate gas.
-func EstimateGasRequestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+// SimulateRequestHandlerFn - http request handler to simulate msgs.
+func SimulateRequestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var req EstimateGasReq
+		var req SimulateReq
 		if !rest.ReadRESTReq(w, r, cliCtx.Codec, &req) {
 			return
 		}

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
@@ -47,9 +46,8 @@ var (
 
 const (
 	lcdEndpoint        = "http://127.0.0.1:1317/"
-	pollingInterval    = 500 * time.Millisecond     // half a block
-	pollingTimeout     = 10 * time.Second           // 10 blocks
-	gasLimit           = flags.DefaultGasLimit * 10 // x10 so the biggest txs have enough gas
+	pollingInterval    = 500 * time.Millisecond // half a block
+	pollingTimeout     = 10 * time.Second       // 10 blocks
 	cliAccountMnemonic = "large fork soccer lab answer enlist robust vacant narrow please inmate primary father must add hub shy couch rail video tool marine pill give"
 	cliAccountName     = "cli"
 	cliAccountPassword = "pass"
@@ -89,7 +87,7 @@ func TestAPI(t *testing.T) {
 	cliAddress = cliAcc.GetAddress()
 
 	// init LCD with engine account and make a transfer to cli account
-	lcdEngine, err = cosmos.NewLCD(lcdEndpoint, cdc, kb, cfg.DevGenesis.ChainID, cfg.Account.Name, cfg.Account.Password, cfg.Cosmos.MinGasPrices, gasLimit)
+	lcdEngine, err = cosmos.NewLCD(lcdEndpoint, cdc, kb, cfg.DevGenesis.ChainID, cfg.Account.Name, cfg.Account.Password, cfg.Cosmos.MinGasPrices)
 	require.NoError(t, err)
 	_, err = lcdEngine.BroadcastMsg(bank.NewMsgSend(engineAddress, cliAddress, cliInitialBalance))
 	require.NoError(t, err)
@@ -109,7 +107,7 @@ func TestAPI(t *testing.T) {
 	}
 
 	// init LCD
-	lcd, err = cosmos.NewLCD(lcdEndpoint, cdc, kb, cfg.DevGenesis.ChainID, cliAccountName, cliAccountPassword, cfg.Cosmos.MinGasPrices, gasLimit)
+	lcd, err = cosmos.NewLCD(lcdEndpoint, cdc, kb, cfg.DevGenesis.ChainID, cliAccountName, cliAccountPassword, cfg.Cosmos.MinGasPrices)
 	require.NoError(t, err)
 
 	// run tests


### PR DESCRIPTION
This PR adds the LCD endpoint POST `/txs/simulate` to estimate the gas on a transaction.

I suggest releasing this feature quickly and update the CLI.