### PR TITLE
Add tx commands for service, process, execution and runner modules

### DIFF
--- a/x/execution/client/cli/tx.go
+++ b/x/execution/client/cli/tx.go
@@ -1,11 +1,17 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 	"github.com/mesg-foundation/engine/x/execution/internal/types"
 	"github.com/spf13/cobra"
 )
@@ -14,12 +20,75 @@ import (
 func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	executionTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      fmt.Sprintf("%s transactions subcommands", types.ModuleName),
+		Short:                      fmt.Sprintf("%s transactions subcommands", strings.Title(types.ModuleName)),
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
 
-	executionTxCmd.AddCommand(flags.PostCommands()...)
+	executionTxCmd.AddCommand(flags.PostCommands(
+		GetCmdCreate(cdc),
+		GetCmdUpdate(cdc),
+	)...)
 	return executionTxCmd
+}
+
+// GetCmdCreate is the command to create a execution.
+func GetCmdCreate(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "create [definition]",
+		Short: "Creates a new execution",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			rawMsg := fmt.Sprintf(`{"type":"execution/create","value":%s}`, args[0])
+			var msg types.MsgCreate
+			if err := cdc.UnmarshalJSON([]byte(rawMsg), &msg); err != nil {
+				return err
+			}
+			if !msg.Signer.Empty() && !msg.Signer.Equals(cliCtx.FromAddress) {
+				return fmt.Errorf("the signer set in the definition is not the same as the from flag")
+			}
+			msg.Signer = cliCtx.FromAddress
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
+}
+
+// GetCmdUpdate is the command to update a execution.
+func GetCmdUpdate(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "update [definition]",
+		Short: "Updates an execution",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			rawMsg := fmt.Sprintf(`{"type":"execution/update","value":%s}`, args[0])
+			var msg types.MsgUpdate
+			if err := cdc.UnmarshalJSON([]byte(rawMsg), &msg); err != nil {
+				return err
+			}
+			if !msg.Executor.Empty() && !msg.Executor.Equals(cliCtx.FromAddress) {
+				return fmt.Errorf("the executor set in the definition is not the same as the from flag")
+			}
+			msg.Executor = cliCtx.FromAddress
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
 }

--- a/x/instance/client/cli/tx.go
+++ b/x/instance/client/cli/tx.go
@@ -1,25 +1,11 @@
 package cli
 
 import (
-	"fmt"
-
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/mesg-foundation/engine/x/instance/internal/types"
 	"github.com/spf13/cobra"
 )
 
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd(cdc *codec.Codec) *cobra.Command {
-	ownershipTxCmd := &cobra.Command{
-		Use:                        types.ModuleName,
-		Short:                      fmt.Sprintf("%s transactions subcommands", types.ModuleName),
-		DisableFlagParsing:         true,
-		SuggestionsMinimumDistance: 2,
-		RunE:                       client.ValidateCmd,
-	}
-
-	ownershipTxCmd.AddCommand(flags.PostCommands()...)
-	return ownershipTxCmd
+	return nil
 }

--- a/x/ownership/client/cli/tx.go
+++ b/x/ownership/client/cli/tx.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"fmt"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -20,7 +21,7 @@ import (
 func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	ownershipTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      fmt.Sprintf("%s transactions subcommands", types.ModuleName),
+		Short:                      fmt.Sprintf("%s transactions subcommands", strings.Title(types.ModuleName)),
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
@@ -35,8 +36,8 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 // GetCmdWithdraw is the CLI command for sending a Withdraw transaction
 func GetCmdWithdraw(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "withdraw-coins [resource] [amount]",
-		Short: "withdraw amount from resource address",
+		Use:   "withdraw-coins [resourceHash] [amount]",
+		Short: "withdraw coins from a resource",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
@@ -44,17 +45,17 @@ func GetCmdWithdraw(cdc *codec.Codec) *cobra.Command {
 
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 
-			h, err := hash.Decode(args[0])
+			resourceHash, err := hash.Decode(args[0])
 			if err != nil {
 				return err
 			}
 
 			msg := types.MsgWithdraw{
 				Owner:        cliCtx.GetFromAddress(),
-				ResourceHash: h,
+				ResourceHash: resourceHash,
 				Amount:       args[1],
 			}
-			if err = msg.ValidateBasic(); err != nil {
+			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
 

--- a/x/process/client/cli/tx.go
+++ b/x/process/client/cli/tx.go
@@ -1,11 +1,18 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/x/process/internal/types"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +21,7 @@ import (
 func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	processTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      fmt.Sprintf("%s transactions subcommands", types.ModuleName),
+		Short:                      fmt.Sprintf("%s transactions subcommands", strings.Title(types.ModuleName)),
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
@@ -28,26 +35,62 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	return processTxCmd
 }
 
+// GetCmdCreate is the command to create a process.
 func GetCmdCreate(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "create [serviceHash] [key=val]...",
+		Use:   "create [definition]",
 		Short: "Creates a new process",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO:
-			return nil
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			rawMsg := fmt.Sprintf(`{"type":"process/create","value":%s}`, args[0])
+			var msg types.MsgCreate
+			if err := cdc.UnmarshalJSON([]byte(rawMsg), &msg); err != nil {
+				return err
+			}
+			if !msg.Owner.Empty() && !msg.Owner.Equals(cliCtx.FromAddress) {
+				return fmt.Errorf("the owner set in the definition is not the same as the from flag")
+			}
+			msg.Owner = cliCtx.FromAddress
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}
 }
 
+// GetCmdDelete is the command to delete a process.
 func GetCmdDelete(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "create [serviceHash] [key=val]...",
-		Short: "Creates a new process",
-		Args:  cobra.MinimumNArgs(1),
+		Use:   "delete [processHash]",
+		Short: "Deletes a process",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO:
-			return nil
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			processHash, err := hash.Decode(args[0])
+			if err != nil {
+				return fmt.Errorf("arg processHash error: %w", err)
+			}
+
+			msg := types.MsgDelete{
+				Hash:  processHash,
+				Owner: cliCtx.FromAddress,
+			}
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}
 }

--- a/x/runner/client/cli/tx.go
+++ b/x/runner/client/cli/tx.go
@@ -1,11 +1,18 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+	"github.com/mesg-foundation/engine/hash"
 	"github.com/mesg-foundation/engine/x/runner/internal/types"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +21,7 @@ import (
 func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	runnerTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      fmt.Sprintf("%s transactions subcommands", types.ModuleName),
+		Short:                      fmt.Sprintf("%s transactions subcommands", strings.Title(types.ModuleName)),
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
@@ -28,26 +35,70 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	return runnerTxCmd
 }
 
+// GetCmdCreate is the command to create a runner.
 func GetCmdCreate(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "create [runnerHash] [key=val]...",
+		Use:   "create [serviceHash] [envHash]",
 		Short: "Creates a new runner",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO:
-			return nil
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			serviceHash, err := hash.Decode(args[0])
+			if err != nil {
+				return fmt.Errorf("arg serviceHash error: %w", err)
+			}
+
+			var envHash hash.Hash
+			if len(args) >= 2 && args[1] != "" {
+				if envHash, err = hash.Decode(args[1]); err != nil {
+					return fmt.Errorf("arg envHash error: %w", err)
+				}
+			}
+
+			msg := types.MsgCreate{
+				ServiceHash: serviceHash,
+				EnvHash:     envHash,
+				Owner:       cliCtx.FromAddress,
+			}
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}
 }
 
+// GetCmdDelete is the command to delete a runner.
 func GetCmdDelete(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete [runnerHash] [key=val]...",
-		Short: "Creates a new runner",
-		Args:  cobra.MinimumNArgs(1),
+		Use:   "delete [runnerHash]",
+		Short: "Deletes a runner",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO:
-			return nil
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			runHash, err := hash.Decode(args[0])
+			if err != nil {
+				return fmt.Errorf("arg runHash error: %w", err)
+			}
+
+			msg := types.MsgDelete{
+				Hash:  runHash,
+				Owner: cliCtx.FromAddress,
+			}
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}
 }

--- a/x/service/client/cli/tx.go
+++ b/x/service/client/cli/tx.go
@@ -1,11 +1,17 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 	"github.com/mesg-foundation/engine/x/service/internal/types"
 	"github.com/spf13/cobra"
 )
@@ -14,13 +20,45 @@ import (
 func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	serviceTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      fmt.Sprintf("%s transactions subcommands", types.ModuleName),
+		Short:                      fmt.Sprintf("%s transactions subcommands", strings.Title(types.ModuleName)),
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
 
-	serviceTxCmd.AddCommand(flags.PostCommands()...)
+	serviceTxCmd.AddCommand(flags.PostCommands(
+		GetCmdCreate(cdc),
+	)...)
 
 	return serviceTxCmd
+}
+
+// GetCmdCreate is the CLI command for creating a service.
+func GetCmdCreate(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "create [definition]",
+		Short: "create a service from its definition",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			rawMsg := fmt.Sprintf(`{"type":"service/create","value":%s}`, args[0])
+			var msg types.MsgCreate
+			if err := cdc.UnmarshalJSON([]byte(rawMsg), &msg); err != nil {
+				return err
+			}
+			if !msg.Owner.Empty() && !msg.Owner.Equals(cliCtx.FromAddress) {
+				return fmt.Errorf("the owner set in the definition is not the same as the from flag")
+			}
+			msg.Owner = cliCtx.FromAddress
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
 }


### PR DESCRIPTION
Add write commands for all modules

The commands `service create`, `process create`, `execution create` and `execution update` require the data to be passed as JSON because of the complexity of the data.
It makes them hard to use as the JSON is also complicated to write.
@antho1404 do you have a suggestion to improve this issue? Should I make a simple version based on flags but that can only fill the root keys?

Example of use:
```
go run ./cmd/mesg-cli tx service create  --from engine2 --chain-id "mesg-dev-chain" -b block --gas-prices=1.0atto '{"sid":"emit-event-interval","name":"Service Emit Event Interval","description":"Emits events on regular intervals","repository":"https://github.com/liteflow-services/emit-event-interval","configuration":{},"dependencies":[],"tasks":[],"events":[{"key":"every_1_second","name":"Every 1 second","description":"Emits an event every 1 second","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_2_seconds","name":"Every 2 seconds","description":"Emits an event every 2 seconds","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_5_seconds","name":"Every 5 seconds","description":"Emits an event every 5 seconds","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_10_seconds","name":"Every 10 seconds","description":"Emits an event every 10 seconds","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_30_seconds","name":"Every 30 seconds","description":"Emits an event every 30 seconds","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_1_minute","name":"Every 1 minute","description":"Emits an event every 1 minute","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_2_minutes","name":"Every 2 minutes","description":"Emits an event every 2 minutes","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_5_minutes","name":"Every 5 minutes","description":"Emits an event every 5 minutes","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_10_minutes","name":"Every 10 minutes","description":"Emits an event every 10 minutes","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_30_minutes","name":"Every 30 minutes","description":"Emits an event every 30 minutes","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_1_hour","name":"Every 1 hour","description":"Emits an event every 1 hour","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_2_hours","name":"Every 2 hours","description":"Emits an event every 2 hours","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_6_hours","name":"Every 6 hours","description":"Emits an event every 6 hours","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_12_hours","name":"Every 12 hours","description":"Emits an event every 12 hours","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]},{"key":"every_24_hours","name":"Every 24 hours","description":"Emits an event every 24 hours","data":[{"key":"timestamp","name":"Timestamp (ms)","description":"The timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC","type":"Number","object":[]}]}],"source":"QmPNUbFGZa5hvVCf1CAjFLfv5ZTykgpkU6sYXYXAEMzQMH"}'

go run ./cmd/mesg-cli tx runner create SERVICE_HASH --from engine2 --chain-id "mesg-dev-chain" -b block --gas-prices=1.0atto
go run ./cmd/mesg-cli tx runner delete RUNNER_HASH --from engine2 --chain-id "mesg-dev-chain" -b block --gas-prices=1.0atto

# TODO: add the args
go run ./cmd/mesg-cli tx process create --from engine --chain-id "mesg-dev-chain" -b block --gas-prices=1.0atto '{"name":"webhook","nodes":[{"key":"node-0","Type":{"type":"mesg.types.Process_Node_Event_","value":{"event":{"instanceHash":"8dD91Yx9N7kywn8MtQ9PxReWpdjpeGgSMvZsgWcnG27y","eventKey":"every_10_seconds"}}}},{"key":"node-1-inputs","Type":{"type":"mesg.types.Process_Node_Map_","value":{"map":[{"Key":"data","Value":{"Value":{"type":"mesg.types.Process_Node_Map_Output_Map_","value":{"map":[{"Key":"foo","Value":{"Value":{"type":"mesg.types.Process_Node_Map_Output_StringConst","value":{"string_const":"bar"}}}}]}}}},{"Key":"url","Value":{"Value":{"type":"mesg.types.Process_Node_Map_Output_StringConst","value":{"string_const":"https://webhook.site/ad536a28-4b19-4562-a756-f20027e25c5a"}}}}]}}},{"key":"node-1","Type":{"type":"mesg.types.Process_Node_Task_","value":{"task":{"instanceHash":"HVso8L6QtToBNomhDvnfobygr6YAtmXRAqdkJsw9s36e","taskKey":"call"}}}}],"edges":[{"src":"node-0","dst":"node-1-inputs"},{"src":"node-1-inputs","dst":"node-1"}]}'

go run ./cmd/mesg-cli tx process delete --from ACCOUNT --chain-id "mesg-dev-chain" -b block --gas-prices=1.0atto 9hFpz4Mq5KBfwVzKSoCEr3hFC1DFicEkMx13Uyr7oKWj

go run ./cmd/mesg-cli tx execution create --from engine --chain-id "mesg-dev-chain" -b block --gas-prices=1.0atto --yes '{"taskKey":"call","eventHash":"9hFpz4Mq5KBfwVzKSoCEr3hFC1DFicEkMx13Uyr7oKWj","executorHash":"8xdAhmoXcYtMobe6xwjMboDGPhqE7iMjY1iJ2WjbLwVS","price":"10000atto"}'

go run ./cmd/mesg-cli tx execution update --from engine --chain-id "mesg-dev-chain" -b block --gas-prices=1.0atto --yes '{"hash":"9hFpz4Mq5KBfwVzKSoCEr3hFC1DFicEkMx13Uyr7oKWj","executor":"mesgXXX","result":""}'
```