### PR TITLE
Add cli dockerfile

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -11,7 +11,7 @@ ARG version
 RUN go build -mod=readonly -o ./bin/mesg-cli -ldflags="-s -w -X 'github.com/cosmos/cosmos-sdk/version.Name=mesg' -X 'github.com/cosmos/cosmos-sdk/version.ServerName=mesg-daemon' -X 'github.com/cosmos/cosmos-sdk/version.ClientName=mesg-cli' -X 'github.com/cosmos/cosmos-sdk/version.Version=$version'" ./cmd/mesg-cli/
 RUN go build -mod=readonly -o ./bin/mesg-daemon -ldflags="-s -w -X 'github.com/cosmos/cosmos-sdk/version.Name=mesg' -X 'github.com/cosmos/cosmos-sdk/version.ServerName=mesg-daemon' -X 'github.com/cosmos/cosmos-sdk/version.ClientName=mesg-cli' -X 'github.com/cosmos/cosmos-sdk/version.Version=$version'" ./cmd/mesg-daemon/
 
-# ubuntu image wit binaries for distribution
+# ubuntu image with binaries for distribution
 FROM ubuntu:18.04
 RUN apt-get update && \
   apt-get install -y --no-install-recommends ca-certificates=20180409 && \

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,27 @@
+# base Go image version for building the binaries
+FROM golang:1.13.10 AS build
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG version
+
+RUN go build -mod=readonly -o ./bin/mesg-cli -ldflags="-s -w -X 'github.com/cosmos/cosmos-sdk/version.Name=mesg' -X 'github.com/cosmos/cosmos-sdk/version.ServerName=mesg-daemon' -X 'github.com/cosmos/cosmos-sdk/version.ClientName=mesg-cli' -X 'github.com/cosmos/cosmos-sdk/version.Version=$version'" ./cmd/mesg-cli/
+RUN go build -mod=readonly -o ./bin/mesg-daemon -ldflags="-s -w -X 'github.com/cosmos/cosmos-sdk/version.Name=mesg' -X 'github.com/cosmos/cosmos-sdk/version.ServerName=mesg-daemon' -X 'github.com/cosmos/cosmos-sdk/version.ClientName=mesg-cli' -X 'github.com/cosmos/cosmos-sdk/version.Version=$version'" ./cmd/mesg-daemon/
+
+# ubuntu image wit binaries for distribution
+FROM ubuntu:18.04
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates=20180409 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+ENV PATH="/app:${PATH}"
+
+COPY --from=build /app/bin/mesg-cli .
+COPY --from=build /app/bin/mesg-daemon .
+
+CMD ["mesg-daemon", "start"]

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,5 +1,5 @@
 # base Go image version.
-FROM golang:1.13.0-stretch
+FROM golang:1.13.10
 
 WORKDIR /project
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-cmd-cosmos changelog check-version clean clean-build clean-docker dep dev dev-mon dev-start dev-stop docker-build docker-dev docker-publish docker-publish-dev docker-tools genesis lint protobuf test publish-cmds
+.PHONY: all build build-cmd-cosmos changelog check-version clean clean-build clean-docker dep dev dev-mon dev-start dev-stop docker-build docker-dev docker-publish docker-publish-dev docker-tools genesis lint protobuf test publish-cmds build-docker-cli
 
 MAJOR_VERSION := $(shell echo $(version) | cut -d . -f 1)
 MINOR_VERSION := $(shell echo $(version) | cut -d . -f 1-2)
@@ -60,6 +60,9 @@ publish-cmds: check-version dep
 build-cmd: dep
 	go build -mod=readonly -o ./bin/mesg-cli ./cmd/mesg-cli/
 	go build -mod=readonly -o ./bin/mesg-daemon ./cmd/mesg-daemon/
+
+build-docker-cli: check-version
+	docker build -t mesg/engine:cli -f ./Dockerfile.cli --build-arg version=$(version) .
 
 e2e: docker-dev
 	./scripts/run-e2e.sh


### PR DESCRIPTION
This PR adds a new Dockerfile that compiles and exposes the 2 clis.
The default dockerfile cmd is using only on cli, but the otherone can still be usable by overriding the default cmd when starting the container.