### PR TITLE
fix runner e2e that block the tests on error

### DIFF
--- a/e2e/runner_test.go
+++ b/e2e/runner_test.go
@@ -69,9 +69,10 @@ func testRunner(t *testing.T) {
 			require.NoError(t, cont.Start(testServiceStruct, testInstanceHash, testRunnerHash, testInstanceEnvHash, testInstanceEnv, registerPayloadSignature))
 		})
 
-		// wait for service to be ready
-		_, err = stream.Recv()
-		require.NoError(t, err)
+		t.Run("wait", func(t *testing.T) {
+			_, err = stream.Recv()
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("get", func(t *testing.T) {


### PR DESCRIPTION
fix runner e2e that block the tests on error

to remember: when a `require.` function "fail" it will not run other `t.Run` functions but will run the remaining code in the parent function.