### PR TITLE
Add filter on execution list

### DIFF
--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -145,13 +145,11 @@ func pollExecutionOfProcess(processHash hash.Hash, status execution.Status, node
 	timeout := time.After(pollingTimeout)
 	for {
 		var execs []*execution.Execution
-		if err := lcd.Get("execution/list", &execs); err != nil {
+		if err := lcd.Get(fmt.Sprintf("execution/list?processHash=%s&status=%s&nodeKey=%s", processHash, status, nodeKey), &execs); err != nil {
 			return nil, err
 		}
-		for _, exec := range execs {
-			if exec.ProcessHash.Equal(processHash) && exec.Status == status && exec.NodeKey == nodeKey {
-				return exec, nil
-			}
+		if len(execs) > 0 {
+			return execs[0], nil
 		}
 		select {
 		case <-time.After(pollingInterval):

--- a/x/execution/client/rest/query.go
+++ b/x/execution/client/rest/query.go
@@ -109,6 +109,10 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			filter.Status = execution.Status(status)
 		}
 
+		if param := r.FormValue("nodeKey"); param != "" {
+			filter.NodeKey = param
+		}
+
 		data, err := cliCtx.Codec.MarshalJSON(filter)
 		if err != nil {
 			return

--- a/x/execution/client/rest/query.go
+++ b/x/execution/client/rest/query.go
@@ -67,7 +67,7 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if param := r.FormValue("parentHash"); param != "" {
 			h, err := hash.Decode(param)
 			if err != nil {
-				rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+				rest.WriteErrorResponse(w, http.StatusBadRequest, "error on parameter parentHash: "+err.Error())
 				return
 			}
 			filter.ParentHash = h
@@ -76,7 +76,7 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if param := r.FormValue("eventHash"); param != "" {
 			h, err := hash.Decode(param)
 			if err != nil {
-				rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+				rest.WriteErrorResponse(w, http.StatusBadRequest, "error on parameter eventHash: "+err.Error())
 				return
 			}
 			filter.EventHash = h
@@ -85,7 +85,7 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if param := r.FormValue("instanceHash"); param != "" {
 			h, err := hash.Decode(param)
 			if err != nil {
-				rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+				rest.WriteErrorResponse(w, http.StatusBadRequest, "error on parameter instanceHash: "+err.Error())
 				return
 			}
 			filter.InstanceHash = h
@@ -94,7 +94,7 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if param := r.FormValue("processHash"); param != "" {
 			h, err := hash.Decode(param)
 			if err != nil {
-				rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+				rest.WriteErrorResponse(w, http.StatusBadRequest, "error on parameter processHash: "+err.Error())
 				return
 			}
 			filter.ProcessHash = h
@@ -103,7 +103,7 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if param := r.FormValue("status"); param != "" {
 			status, ok := execution.Status_value[param]
 			if !ok {
-				rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("%q is invalid", param))
+				rest.WriteErrorResponse(w, http.StatusBadRequest, "error on parameter status: value is invalid")
 				return
 			}
 			filter.Status = execution.Status(status)
@@ -115,6 +115,7 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 
 		data, err := cliCtx.Codec.MarshalJSON(filter)
 		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		res, height, err := cliCtx.QueryWithData(route, data)

--- a/x/execution/internal/keeper/keeper.go
+++ b/x/execution/internal/keeper/keeper.go
@@ -348,7 +348,7 @@ func (k *Keeper) Get(ctx sdk.Context, hash hash.Hash) (*executionpb.Execution, e
 }
 
 // List returns all executions.
-func (k *Keeper) List(ctx sdk.Context) ([]*executionpb.Execution, error) {
+func (k *Keeper) List(ctx sdk.Context, filter types.ListFilter) ([]*executionpb.Execution, error) {
 	var (
 		execs []*executionpb.Execution
 		iter  = ctx.KVStore(k.storeKey).Iterator(nil, nil)
@@ -359,7 +359,9 @@ func (k *Keeper) List(ctx sdk.Context) ([]*executionpb.Execution, error) {
 		if err := k.cdc.UnmarshalBinaryLengthPrefixed(value, &exec); err != nil {
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrJSONUnmarshal, err.Error())
 		}
-		execs = append(execs, exec)
+		if filter.Match(exec) {
+			execs = append(execs, exec)
+		}
 		iter.Next()
 	}
 	iter.Close()

--- a/x/execution/internal/keeper/querier.go
+++ b/x/execution/internal/keeper/querier.go
@@ -15,7 +15,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 		case types.QueryGet:
 			return get(ctx, k, path[1:])
 		case types.QueryList:
-			return list(ctx, k)
+			return list(ctx, k, req.Data)
 		default:
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown execution query endpoint")
 		}
@@ -43,8 +43,12 @@ func get(ctx sdk.Context, k Keeper, path []string) ([]byte, error) {
 	return res, nil
 }
 
-func list(ctx sdk.Context, k Keeper) ([]byte, error) {
-	es, err := k.List(ctx)
+func list(ctx sdk.Context, k Keeper, data []byte) ([]byte, error) {
+	var filter types.ListFilter
+	if err := types.ModuleCdc.UnmarshalJSON(data, &filter); err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+	}
+	es, err := k.List(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/x/execution/internal/types/querier.go
+++ b/x/execution/internal/types/querier.go
@@ -18,13 +18,28 @@ type ListFilter struct {
 	InstanceHash hash.Hash        `json:"instanceHash"`
 	ProcessHash  hash.Hash        `json:"processHash"`
 	Status       execution.Status `json:"status"`
+	NodeKey      string           `json:"nodeKey"`
 }
 
 // Match returns true if an execution matches a specific filter
 func (f ListFilter) Match(exec *execution.Execution) bool {
-	return (f.Status == execution.Status_Unknown || f.Status == exec.Status) &&
-		(f.ProcessHash.IsZero() || f.ProcessHash.Equal(exec.ProcessHash)) &&
-		(f.InstanceHash.IsZero() || f.InstanceHash.Equal(exec.InstanceHash)) &&
-		(f.ParentHash.IsZero() || f.ParentHash.Equal(exec.ParentHash)) &&
-		(f.EventHash.IsZero() || f.EventHash.Equal(exec.EventHash))
+	if f.Status != execution.Status_Unknown && f.Status != exec.Status {
+		return false
+	}
+	if !f.ProcessHash.IsZero() && !f.ProcessHash.Equal(exec.ProcessHash) {
+		return false
+	}
+	if !f.InstanceHash.IsZero() && !f.InstanceHash.Equal(exec.InstanceHash) {
+		return false
+	}
+	if !f.ParentHash.IsZero() && !f.ParentHash.Equal(exec.ParentHash) {
+		return false
+	}
+	if !f.EventHash.IsZero() && !f.EventHash.Equal(exec.EventHash) {
+		return false
+	}
+	if f.NodeKey != "" && f.NodeKey != exec.NodeKey {
+		return false
+	}
+	return true
 }

--- a/x/execution/internal/types/querier.go
+++ b/x/execution/internal/types/querier.go
@@ -1,6 +1,30 @@
 package types
 
+import (
+	"github.com/mesg-foundation/engine/execution"
+	"github.com/mesg-foundation/engine/hash"
+)
+
+// Querier names
 const (
 	QueryGet  = "get"
 	QueryList = "list"
 )
+
+// ListFilter available for the List
+type ListFilter struct {
+	ParentHash   hash.Hash        `json:"parentHash"`
+	EventHash    hash.Hash        `json:"eventHash"`
+	InstanceHash hash.Hash        `json:"instanceHash"`
+	ProcessHash  hash.Hash        `json:"processHash"`
+	Status       execution.Status `json:"status"`
+}
+
+// Match returns true if an execution matches a specific filter
+func (f ListFilter) Match(exec *execution.Execution) bool {
+	return (f.Status == execution.Status_Unknown || f.Status == exec.Status) &&
+		(f.ProcessHash.IsZero() || f.ProcessHash.Equal(exec.ProcessHash)) &&
+		(f.InstanceHash.IsZero() || f.InstanceHash.Equal(exec.InstanceHash)) &&
+		(f.ParentHash.IsZero() || f.ParentHash.Equal(exec.ParentHash)) &&
+		(f.EventHash.IsZero() || f.EventHash.Equal(exec.EventHash))
+}


### PR DESCRIPTION
Add filter for execution list on the keeper.

Filter available:
- parentHash: base58 hash
- eventHash: base58 hash
- instanceHash: base58 hash
- processHash: base58 hash
- status string (Proposed, InProgress, Completed, Failed)
- stepKey: string

These filters are available as query parameter in the `/execution/list` API 
eg:
```
curl http://localhost:1317/execution/list\?instanceHash\=7dTayprXsBTzc7Z6iqCTjfJzh3Sbtasdgh9wdPzT4gUL\&processHash\=BACectqn5sHeDfK7N6dQdCKKY9ZfrCt5Rh428RYERYXU
```