### PR TITLE
Add pagination meta data in the header

### DIFF
--- a/x/execution/client/rest/query.go
+++ b/x/execution/client/rest/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -133,9 +134,9 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		sort.Sort(sort.Reverse(execution.ByBlockHeight(execs)))
 
 		start, end := client.Paginate(len(execs), page, limit, limit)
-		w.Header().Set("X-Page", fmt.Sprintf("%d", page))
-		w.Header().Set("X-Limit", fmt.Sprintf("%d", limit))
-		w.Header().Set("X-Total-Count", fmt.Sprintf("%d", len(execs)))
+		w.Header().Set("X-Page", strconv.Itoa(page))
+		w.Header().Set("X-Limit", strconv.Itoa(limit))
+		w.Header().Set("X-Total-Count", strconv.Itoa(len(execs)))
 		if start < 0 || end < 0 {
 			execs = []*execution.Execution{}
 		} else {

--- a/x/execution/client/rest/query.go
+++ b/x/execution/client/rest/query.go
@@ -132,6 +132,9 @@ func queryListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		sort.Sort(sort.Reverse(execution.ByBlockHeight(execs)))
 
 		start, end := client.Paginate(len(execs), page, limit, limit)
+		w.Header().Set("X-Page", fmt.Sprintf("%d", page))
+		w.Header().Set("X-Limit", fmt.Sprintf("%d", limit))
+		w.Header().Set("X-Total-Count", fmt.Sprintf("%d", len(execs)))
 		if start < 0 || end < 0 {
 			execs = []*execution.Execution{}
 		} else {


### PR DESCRIPTION
dependency: #1825 

Add pagination detail on the header in order to have the client able to calculate the total number of pages.

I use the `X-` that was a recommendation for custom headers. It is not recommended anymore and it is recommended to use HTTP Link headers but those only support prev and next