### PR TITLE
Improve logs for LCD and daemon

### DIFF
--- a/cmd/mesg-daemon/main.go
+++ b/cmd/mesg-daemon/main.go
@@ -50,7 +50,7 @@ func main() {
 			if err := server.PersistentPreRunEFn(ctx)(cmd, args); err != nil {
 				return err
 			}
-			logger, err := tmflags.ParseLogLevel(ctx.Config.LogLevel, ctx.Logger, cfg.DefaultLogLevel())
+			logger, err := tmflags.ParseLogLevel(ctx.Config.LogLevel, log.NewTMJSONLogger(log.NewSyncWriter(os.Stdout)), cfg.DefaultLogLevel())
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/procfs v0.0.11 // indirect
 	github.com/pseudomuto/protoc-gen-doc v1.3.1
+	github.com/rakyll/statik v0.1.6
 	github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962 // indirect
 	github.com/sirupsen/logrus v1.5.0 // indirect
 	github.com/spf13/afero v1.2.2 // indirect


### PR DESCRIPTION
- [x] Add support of JSON logs for the daemon
- [x] Add custom LCD server with JSON logs

Maybe the custom LCD server command is too much but it is not that complicated and maybe we can have more control on it like CORS or things like that.

@NicolasMahe feel free to merge or close it and just take what you want from it.

I would like tho to have JSON logs everywhere so like that we don't have to do some hacks to skip these logs