### PR TITLE
Implement import and export functions in modules

### DIFF
--- a/x/execution/genesis.go
+++ b/x/execution/genesis.go
@@ -10,6 +10,9 @@ import (
 // and the keeper's address to pubkey map
 func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.ValidatorUpdate {
 	k.SetParams(ctx, data.Params)
+	if err := k.Import(ctx, data.Executions); err != nil {
+		panic(err)
+	}
 	return []abci.ValidatorUpdate{}
 }
 
@@ -18,5 +21,9 @@ func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.Vali
 // with InitGenesis
 func ExportGenesis(ctx sdk.Context, k Keeper) (data types.GenesisState) {
 	params := k.GetParams(ctx)
-	return types.NewGenesisState(params)
+	execs, err := k.List(ctx, types.ListFilter{})
+	if err != nil {
+		panic(err)
+	}
+	return types.NewGenesisState(params, execs)
 }

--- a/x/execution/internal/keeper/keeper.go
+++ b/x/execution/internal/keeper/keeper.go
@@ -469,3 +469,16 @@ func (k *Keeper) fetchEmitters(ctx sdk.Context, proc *process.Process, nodeKey s
 	}
 	return matchedRuns, nil
 }
+
+// Import imports a list of executions into the store.
+func (k *Keeper) Import(ctx sdk.Context, execs []*executionpb.Execution) error {
+	store := ctx.KVStore(k.storeKey)
+	for _, exec := range execs {
+		value, err := k.cdc.MarshalBinaryLengthPrefixed(exec)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrJSONMarshal, err.Error())
+		}
+		store.Set(exec.Hash, value)
+	}
+	return nil
+}

--- a/x/execution/internal/types/genesis.go
+++ b/x/execution/internal/types/genesis.go
@@ -1,23 +1,38 @@
 package types
 
+import (
+	fmt "fmt"
+
+	executionpb "github.com/mesg-foundation/engine/execution"
+	"github.com/mesg-foundation/engine/ext/xvalidator"
+)
+
 // GenesisState - all instance state that must be provided at genesis
 type GenesisState struct {
-	Params Params `json:"params" yaml:"params"`
+	Params     Params                   `json:"params" yaml:"params" validate:"dive"`
+	Executions []*executionpb.Execution `json:"executions" yaml:"executions" validate:"dive"`
 }
 
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState(params Params) GenesisState {
-	return GenesisState{Params: params}
+func NewGenesisState(params Params, execs []*executionpb.Execution) GenesisState {
+	return GenesisState{
+		Params:     params,
+		Executions: execs,
+	}
 }
 
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		Params: DefaultParams(),
+		Params:     DefaultParams(),
+		Executions: nil,
 	}
 }
 
 // ValidateGenesis validates the instance genesis parameters
 func ValidateGenesis(data GenesisState) error {
+	if err := xvalidator.Struct(data); err != nil {
+		return fmt.Errorf("failed to validate %s genesis state: %w", ModuleName, err)
+	}
 	return nil
 }

--- a/x/execution/internal/types/genesis.go
+++ b/x/execution/internal/types/genesis.go
@@ -25,7 +25,7 @@ func NewGenesisState(params Params, execs []*executionpb.Execution) GenesisState
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
 		Params:     DefaultParams(),
-		Executions: nil,
+		Executions: []*executionpb.Execution{},
 	}
 }
 

--- a/x/instance/genesis.go
+++ b/x/instance/genesis.go
@@ -8,11 +8,18 @@ import (
 
 // InitGenesis initialize default parameters and the keeper's address to pubkey map.
 func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.ValidatorUpdate {
+	if err := k.Import(ctx, data.Instances); err != nil {
+		panic(err)
+	}
 	return []abci.ValidatorUpdate{}
 }
 
 // ExportGenesis writes the current store values // to a genesis file,
 // which can be imported again with InitGenesis.
 func ExportGenesis(ctx sdk.Context, k Keeper) types.GenesisState {
-	return types.NewGenesisState()
+	instances, err := k.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return types.NewGenesisState(instances)
 }

--- a/x/instance/internal/keeper/keeper.go
+++ b/x/instance/internal/keeper/keeper.go
@@ -91,3 +91,16 @@ func (k Keeper) List(ctx sdk.Context) ([]*instance.Instance, error) {
 	iter.Close()
 	return items, nil
 }
+
+// Import imports a list of instances into the store.
+func (k *Keeper) Import(ctx sdk.Context, instances []*instance.Instance) error {
+	store := ctx.KVStore(k.storeKey)
+	for _, inst := range instances {
+		value, err := k.cdc.MarshalBinaryLengthPrefixed(inst)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrJSONMarshal, err.Error())
+		}
+		store.Set(inst.Hash, value)
+	}
+	return nil
+}

--- a/x/instance/internal/types/genesis.go
+++ b/x/instance/internal/types/genesis.go
@@ -22,7 +22,7 @@ func NewGenesisState(instances []*instance.Instance) GenesisState {
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		Instances: nil,
+		Instances: []*instance.Instance{},
 	}
 }
 

--- a/x/instance/internal/types/genesis.go
+++ b/x/instance/internal/types/genesis.go
@@ -1,19 +1,35 @@
 package types
 
+import (
+	"fmt"
+
+	"github.com/mesg-foundation/engine/ext/xvalidator"
+	"github.com/mesg-foundation/engine/instance"
+)
+
 // GenesisState - all instance state that must be provided at genesis
-type GenesisState struct{}
+type GenesisState struct {
+	Instances []*instance.Instance `json:"instances" yaml:"instances" validate:"dive"`
+}
 
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState() GenesisState {
-	return GenesisState{}
+func NewGenesisState(instances []*instance.Instance) GenesisState {
+	return GenesisState{
+		Instances: instances,
+	}
 }
 
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
-	return GenesisState{}
+	return GenesisState{
+		Instances: nil,
+	}
 }
 
 // ValidateGenesis validates the instance genesis parameters
 func ValidateGenesis(data GenesisState) error {
+	if err := xvalidator.Struct(data); err != nil {
+		return fmt.Errorf("failed to validate %s genesis state: %w", ModuleName, err)
+	}
 	return nil
 }

--- a/x/ownership/genesis.go
+++ b/x/ownership/genesis.go
@@ -8,11 +8,18 @@ import (
 
 // InitGenesis initialize default parameters and the keeper's address to pubkey map.
 func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.ValidatorUpdate {
+	if err := k.Import(ctx, data.Ownerships); err != nil {
+		panic(err)
+	}
 	return []abci.ValidatorUpdate{}
 }
 
 // ExportGenesis writes the current store values // to a genesis file,
 // which can be imported again with InitGenesis.
 func ExportGenesis(ctx sdk.Context, k Keeper) types.GenesisState {
-	return types.NewGenesisState()
+	ownerships, err := k.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return types.NewGenesisState(ownerships)
 }

--- a/x/ownership/internal/keeper/keeper.go
+++ b/x/ownership/internal/keeper/keeper.go
@@ -168,3 +168,16 @@ func (k Keeper) get(store sdk.KVStore, resourceHash hash.Hash) (*ownership.Owner
 	iter.Close()
 	return nil, nil
 }
+
+// Import imports a list of ownerships into the store.
+func (k *Keeper) Import(ctx sdk.Context, ownerships []*ownership.Ownership) error {
+	store := ctx.KVStore(k.storeKey)
+	for _, own := range ownerships {
+		value, err := k.cdc.MarshalBinaryLengthPrefixed(own)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrJSONMarshal, err.Error())
+		}
+		store.Set(own.Hash, value)
+	}
+	return nil
+}

--- a/x/ownership/internal/types/genesis.go
+++ b/x/ownership/internal/types/genesis.go
@@ -22,7 +22,7 @@ func NewGenesisState(ownerships []*ownership.Ownership) GenesisState {
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		Ownerships: nil,
+		Ownerships: []*ownership.Ownership{},
 	}
 }
 

--- a/x/ownership/internal/types/genesis.go
+++ b/x/ownership/internal/types/genesis.go
@@ -1,19 +1,35 @@
 package types
 
+import (
+	fmt "fmt"
+
+	"github.com/mesg-foundation/engine/ext/xvalidator"
+	"github.com/mesg-foundation/engine/ownership"
+)
+
 // GenesisState - all ownership state that must be provided at genesis
-type GenesisState struct{}
+type GenesisState struct {
+	Ownerships []*ownership.Ownership `json:"ownerships" yaml:"ownerships" validate:"dive"`
+}
 
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState() GenesisState {
-	return GenesisState{}
+func NewGenesisState(ownerships []*ownership.Ownership) GenesisState {
+	return GenesisState{
+		Ownerships: ownerships,
+	}
 }
 
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
-	return GenesisState{}
+	return GenesisState{
+		Ownerships: nil,
+	}
 }
 
 // ValidateGenesis validates the ownership genesis parameters
 func ValidateGenesis(data GenesisState) error {
+	if err := xvalidator.Struct(data); err != nil {
+		return fmt.Errorf("failed to validate %s genesis state: %w", ModuleName, err)
+	}
 	return nil
 }

--- a/x/process/genesis.go
+++ b/x/process/genesis.go
@@ -8,11 +8,18 @@ import (
 
 // InitGenesis initialize default parameters and the keeper's address to pubkey map.
 func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.ValidatorUpdate {
+	if err := k.Import(ctx, data.Processes); err != nil {
+		panic(err)
+	}
 	return []abci.ValidatorUpdate{}
 }
 
 // ExportGenesis writes the current store values // to a genesis file,
 // which can be imported again with InitGenesis.
 func ExportGenesis(ctx sdk.Context, k Keeper) types.GenesisState {
-	return types.NewGenesisState()
+	processes, err := k.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return types.NewGenesisState(processes)
 }

--- a/x/process/internal/keeper/keeper.go
+++ b/x/process/internal/keeper/keeper.go
@@ -164,3 +164,16 @@ func (k Keeper) List(ctx sdk.Context) ([]*processpb.Process, error) {
 	iter.Close()
 	return processes, nil
 }
+
+// Import imports a list of processes into the store.
+func (k *Keeper) Import(ctx sdk.Context, processes []*process.Process) error {
+	store := ctx.KVStore(k.storeKey)
+	for _, proc := range processes {
+		value, err := k.cdc.MarshalBinaryLengthPrefixed(proc)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrJSONMarshal, err.Error())
+		}
+		store.Set(proc.Hash, value)
+	}
+	return nil
+}

--- a/x/process/internal/types/genesis.go
+++ b/x/process/internal/types/genesis.go
@@ -22,7 +22,7 @@ func NewGenesisState(processes []*process.Process) GenesisState {
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		Processes: nil,
+		Processes: []*process.Process{},
 	}
 }
 

--- a/x/process/internal/types/genesis.go
+++ b/x/process/internal/types/genesis.go
@@ -1,19 +1,35 @@
 package types
 
+import (
+	fmt "fmt"
+
+	"github.com/mesg-foundation/engine/ext/xvalidator"
+	"github.com/mesg-foundation/engine/process"
+)
+
 // GenesisState - all instance state that must be provided at genesis
-type GenesisState struct{}
+type GenesisState struct {
+	Processes []*process.Process `json:"processes" yaml:"processes" validate:"dive"`
+}
 
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState() GenesisState {
-	return GenesisState{}
+func NewGenesisState(processes []*process.Process) GenesisState {
+	return GenesisState{
+		Processes: processes,
+	}
 }
 
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
-	return GenesisState{}
+	return GenesisState{
+		Processes: nil,
+	}
 }
 
 // ValidateGenesis validates the instance genesis parameters
 func ValidateGenesis(data GenesisState) error {
+	if err := xvalidator.Struct(data); err != nil {
+		return fmt.Errorf("failed to validate %s genesis state: %w", ModuleName, err)
+	}
 	return nil
 }

--- a/x/runner/genesis.go
+++ b/x/runner/genesis.go
@@ -8,11 +8,18 @@ import (
 
 // InitGenesis initialize default parameters and the keeper's address to pubkey map.
 func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.ValidatorUpdate {
+	if err := k.Import(ctx, data.Runners); err != nil {
+		panic(err)
+	}
 	return []abci.ValidatorUpdate{}
 }
 
 // ExportGenesis writes the current store values // to a genesis file,
 // which can be imported again with InitGenesis.
 func ExportGenesis(ctx sdk.Context, k Keeper) types.GenesisState {
-	return types.NewGenesisState()
+	runners, err := k.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return types.NewGenesisState(runners)
 }

--- a/x/runner/internal/keeper/keeper.go
+++ b/x/runner/internal/keeper/keeper.go
@@ -149,3 +149,16 @@ func (k Keeper) List(ctx sdk.Context) ([]*runner.Runner, error) {
 	iter.Close()
 	return runners, nil
 }
+
+// Import imports a list of runners into the store.
+func (k *Keeper) Import(ctx sdk.Context, runners []*runner.Runner) error {
+	store := ctx.KVStore(k.storeKey)
+	for _, run := range runners {
+		value, err := k.cdc.MarshalBinaryLengthPrefixed(run)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrJSONMarshal, err.Error())
+		}
+		store.Set(run.Hash, value)
+	}
+	return nil
+}

--- a/x/runner/internal/types/genesis.go
+++ b/x/runner/internal/types/genesis.go
@@ -1,19 +1,35 @@
 package types
 
+import (
+	fmt "fmt"
+
+	"github.com/mesg-foundation/engine/ext/xvalidator"
+	"github.com/mesg-foundation/engine/runner"
+)
+
 // GenesisState - all instance state that must be provided at genesis
-type GenesisState struct{}
+type GenesisState struct {
+	Runners []*runner.Runner `json:"runners" yaml:"runners" validate:"dive"`
+}
 
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState() GenesisState {
-	return GenesisState{}
+func NewGenesisState(execs []*runner.Runner) GenesisState {
+	return GenesisState{
+		Runners: execs,
+	}
 }
 
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
-	return GenesisState{}
+	return GenesisState{
+		Runners: nil,
+	}
 }
 
 // ValidateGenesis validates the instance genesis parameters
 func ValidateGenesis(data GenesisState) error {
+	if err := xvalidator.Struct(data); err != nil {
+		return fmt.Errorf("failed to validate %s genesis state: %w", ModuleName, err)
+	}
 	return nil
 }

--- a/x/runner/internal/types/genesis.go
+++ b/x/runner/internal/types/genesis.go
@@ -22,7 +22,7 @@ func NewGenesisState(execs []*runner.Runner) GenesisState {
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		Runners: nil,
+		Runners: []*runner.Runner{},
 	}
 }
 

--- a/x/service/genesis.go
+++ b/x/service/genesis.go
@@ -8,11 +8,18 @@ import (
 
 // InitGenesis initialize default parameters and the keeper's address to pubkey map.
 func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) []abci.ValidatorUpdate {
+	if err := k.Import(ctx, data.Services); err != nil {
+		panic(err)
+	}
 	return []abci.ValidatorUpdate{}
 }
 
 // ExportGenesis writes the current store values // to a genesis file,
 // which can be imported again with InitGenesis.
 func ExportGenesis(ctx sdk.Context, k Keeper) types.GenesisState {
-	return types.NewGenesisState()
+	services, err := k.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return types.NewGenesisState(services)
 }

--- a/x/service/internal/keeper/keeper.go
+++ b/x/service/internal/keeper/keeper.go
@@ -117,3 +117,16 @@ func (k Keeper) List(ctx sdk.Context) ([]*servicepb.Service, error) {
 	iter.Close()
 	return services, nil
 }
+
+// Import imports a list of services into the store.
+func (k *Keeper) Import(ctx sdk.Context, services []*servicepb.Service) error {
+	store := ctx.KVStore(k.storeKey)
+	for _, serv := range services {
+		value, err := k.cdc.MarshalBinaryLengthPrefixed(serv)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrJSONMarshal, err.Error())
+		}
+		store.Set(serv.Hash, value)
+	}
+	return nil
+}

--- a/x/service/internal/types/genesis.go
+++ b/x/service/internal/types/genesis.go
@@ -22,7 +22,7 @@ func NewGenesisState(services []*service.Service) GenesisState {
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		Services: nil,
+		Services: []*service.Service{},
 	}
 }
 

--- a/x/service/internal/types/genesis.go
+++ b/x/service/internal/types/genesis.go
@@ -1,19 +1,35 @@
 package types
 
+import (
+	fmt "fmt"
+
+	"github.com/mesg-foundation/engine/ext/xvalidator"
+	"github.com/mesg-foundation/engine/service"
+)
+
 // GenesisState - all instance state that must be provided at genesis
-type GenesisState struct{}
+type GenesisState struct {
+	Services []*service.Service `json:"services" yaml:"services" validate:"dive"`
+}
 
 // NewGenesisState creates a new GenesisState object
-func NewGenesisState() GenesisState {
-	return GenesisState{}
+func NewGenesisState(services []*service.Service) GenesisState {
+	return GenesisState{
+		Services: services,
+	}
 }
 
 // DefaultGenesisState - default GenesisState used by Cosmos Hub
 func DefaultGenesisState() GenesisState {
-	return GenesisState{}
+	return GenesisState{
+		Services: nil,
+	}
 }
 
 // ValidateGenesis validates the instance genesis parameters
 func ValidateGenesis(data GenesisState) error {
+	if err := xvalidator.Struct(data); err != nil {
+		return fmt.Errorf("failed to validate %s genesis state: %w", ModuleName, err)
+	}
 	return nil
 }


### PR DESCRIPTION
Closes https://github.com/mesg-foundation/engine/issues/1847

This PR implements the import and export functions in modules.

To export, use the command:
```
mesg-daemon export
```
> Make sure the first line returned by the command doesn't contain "WARNING: State is not initialized. Returning genesis file.". If it's the case, try to start the node and stop it `mesg-daemon start`. I think I have this issue because I'm running the node in docker and the cli on mac. So when I start the node on the Mac, it may resolve the issue.

To import, copy the output of previous command in the genesis.json file of a new node that doesn't have any database, start the node, and see the data are present.